### PR TITLE
OFFENCES-47 Test if a deployed version of the service works with SDRS staging without a custom cert store

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,7 @@ COPY --from=builder --chown=appuser:appgroup /app/build/libs/manage-offences-api
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights-agent*.jar /app/agent.jar
 COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.json /app
 COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.dev.json /app
-COPY --chown=appuser:appgroup run.sh /app
-COPY --chown=appuser:appgroup trusted.jks /app/
 
 USER 2000
 
-ENTRYPOINT ["/bin/sh", "/app/run.sh"]
+ENTRYPOINT ["java", "-javaagent:/app/agent.jar", "-jar", "/app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -42,12 +42,20 @@ Run the following commands from the root directory of the project:
 4. ./run-local.sh
 
 ## Connecting to the SDRS staging API
+
+### keytool usage
+Use the keytool command. if modifying cacerts pass in the option `-cacerts`, otherwise the following can modify any truststore `-keystore /etc/ssl/certs/java/cacerts`
+
+### add cert
 The SDRS Staging api is publicly open api with root URL at
 https://api-dev.prison.service.justice.gov.uk
 However, in order for it to work with java you have to add it to the truststore, locally this can be achieved by doing the following and using the default password of changeit
 1. Download the cert from https://api-dev.prison.service.justice.gov.uk using a browser or the following command
    openssl s_client -servername crime-reference-data-api.staging.service.justice.gov.uk -connect crime-reference-data-api.staging.service.justice.gov.uk:443 </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' >sdrs-certificate.pem
-2. keytool -importcert -trustcacerts -keystore /etc/ssl/certs/java/cacerts -file sdrs-certificate.pem -alias sdrs_staging_cert
+2. keytool -noprompt -storepass changeit -importcert -trustcacerts -cacerts -file sdrs-certificate.pem -alias sdrs_staging_cert
 
-### To delete 
-keytool -delete -alias sdrs_staging_cert -keystore /etc/ssl/certs/java/cacerts
+### list cert
+1. keytool -noprompt -storepass changeit -list -v -cacerts
+
+#### delete cert
+keytool -noprompt -storepass changeit -delete -alias sdrs_staging_cert -cacerts


### PR DESCRIPTION
The dockerised version of the cacerts is different to the one I have locally with JDK17... so want to revert the adding of a custom trust store and see if it works with sdrs staging