### PR TITLE
OFFENCES-52 :bug: Downgrade hibernate-core to workaround issue with startsWith and Like JPA queries

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,12 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-actuator")
 
+   Problem with hibernate-core 5.6.7.Final which was causing issue with 'startingWith'
+   https://github.com/spring-projects/spring-data-jpa/issues/2472
+   https://hibernate.atlassian.net/browse/HHH-15142
+   TODO Temporarily revert to 5.6.5.Final until fixed
+  implementation("org.hibernate:hibernate-core:5.6.5.Final")
+
   // Database dependencies
   runtimeOnly("org.flywaydb:flyway-core")
   runtimeOnly("org.postgresql:postgresql:42.3.3")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,10 +19,10 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-actuator")
 
-   Problem with hibernate-core 5.6.7.Final which was causing issue with 'startingWith'
-   https://github.com/spring-projects/spring-data-jpa/issues/2472
-   https://hibernate.atlassian.net/browse/HHH-15142
-   TODO Temporarily revert to 5.6.5.Final until fixed
+  // Problem with hibernate-core 5.6.7.Final which was causing issue with 'startingWith'
+  // https://github.com/spring-projects/spring-data-jpa/issues/2472
+  // https://hibernate.atlassian.net/browse/HHH-15142
+  // TODO Temporarily revert to 5.6.5.Final until fixed
   implementation("org.hibernate:hibernate-core:5.6.5.Final")
 
   // Database dependencies


### PR DESCRIPTION
Adopting the same workaround as prison-api
https://github.com/ministryofjustice/prison-api/pull/1226/files

Problem with hibernate-core 5.6.7.Final which was causing issue with 'startingWith'
https://github.com/spring-projects/spring-data-jpa/issues/2472
https://hibernate.atlassian.net/browse/HHH-15142