### PR TITLE
OFFENCES-58 Handle SDRS No cache error and treat as success with no returned offences + add home office stats code

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/entity/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/entity/Offence.kt
@@ -20,6 +20,7 @@ data class Offence(
   val revisionId: Int? = null,
   val startDate: LocalDate? = null,
   val endDate: LocalDate? = null,
+  val homeOfficeStatsCode: String? = null,
   val changedDate: LocalDateTime? = null,
   val createdDate: LocalDateTime = LocalDateTime.now(),
   val lastUpdatedDate: LocalDateTime = LocalDateTime.now(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/enum/SdrsErrorCodes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/enum/SdrsErrorCodes.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.enum
+
+enum class SdrsErrorCodes(val errorCode: String, val description: String) {
+  SDRS_99908("SDRS-99908", "The request UUID is not unique"),
+  SDRS_99918("SDRS-99918", "The specified cache file is not present in the SDRS cache folder");
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/Offence.kt
@@ -20,6 +20,8 @@ data class Offence(
   val startDate: LocalDate? = null,
   @Schema(description = "The offence end date")
   val endDate: LocalDate? = null,
+  @Schema(description = "The offence's home office stats code")
+  val homeOfficeStatsCode: String? = null,
   @Schema(description = "The date this offence was last changed in SDRS")
   val changedDate: LocalDateTime? = null,
   @Schema(description = "The date this offence was loaded into manage-offences from SDRS")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/external/sdrs/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/external/sdrs/Offence.kt
@@ -13,6 +13,8 @@ data class Offence(
   val code: String,
   val description: String? = null,
   val cjsTitle: String? = null,
+  @JsonProperty("MOJStatsCode")
+  val mojStatsCode: String? = null,
   val offenceStartDate: LocalDate? = null,
   val offenceEndDate: LocalDate? = null,
   val changedDate: LocalDateTime? = null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/repository/SdrsLoadStatusRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/repository/SdrsLoadStatusRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.SdrsLoadResult
 
 @Repository
-interface SdrsLoadStatusRepository : JpaRepository<SdrsLoadResult, String>
+interface SdrsLoadStatusRepository : JpaRepository<SdrsLoadResult, String> {
+  fun findAllByOrderByAlphaCharAsc(): List<SdrsLoadResult>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/OffenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/OffenceService.kt
@@ -20,7 +20,7 @@ class OffenceService(
 
   fun findLoadResults(): List<MostRecentLoadResult> {
     log.info("Fetching offences by offenceCode")
-    return sdrsLoadStatusRepository.findAll().map { transform(it) }
+    return sdrsLoadStatusRepository.findAllByOrderByAlphaCharAsc().map { transform(it) }
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/TransformFunctions.kt
@@ -18,6 +18,7 @@ fun transform(offence: Offence): ModelOffence =
     revisionId = offence.revisionId,
     startDate = offence.startDate,
     endDate = offence.endDate,
+    homeOfficeStatsCode = offence.homeOfficeStatsCode,
     changedDate = offence.changedDate,
     loadDate = offence.lastUpdatedDate,
   )
@@ -29,6 +30,7 @@ fun transform(sdrsOffence: SdrsOffence): Offence = Offence(
   revisionId = sdrsOffence.offenceRevisionId,
   startDate = sdrsOffence.offenceStartDate,
   endDate = sdrsOffence.offenceEndDate,
+  homeOfficeStatsCode = sdrsOffence.mojStatsCode,
   changedDate = sdrsOffence.changedDate
 )
 
@@ -39,6 +41,7 @@ fun transform(sdrsOffence: SdrsOffence, offence: Offence): Offence =
     revisionId = sdrsOffence.offenceRevisionId,
     startDate = sdrsOffence.offenceStartDate,
     endDate = sdrsOffence.offenceEndDate,
+    homeOfficeStatsCode = sdrsOffence.mojStatsCode, // TODO may need to pad this out with zeroes eg 052/01 instead of 52/1
     changedDate = sdrsOffence.changedDate
   )
 

--- a/src/main/resources/migration/common/V4__add_home_office_stats_column.sql
+++ b/src/main/resources/migration/common/V4__add_home_office_stats_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE offence ADD COLUMN home_office_stats_code VARCHAR(6);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/integration/wiremock/SDRSApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/integration/wiremock/SDRSApiMockServer.kt
@@ -34,6 +34,7 @@ class SDRSApiMockServer : WireMockServer(WIREMOCK_PORT) {
                               "OffenceStartDate": "2013-03-01",
 						                  "OffenceEndDate": "2013-03-02",
                               "Description": "EMPTY TEMPLATE FOR USE WHERE A STANDARD OFFENCE WORDING IS NOT AVAILABLE",
+                              "MOJStatsCode": "195/99",
                               "code": "XX99001"
                             },
                             {
@@ -41,6 +42,7 @@ class SDRSApiMockServer : WireMockServer(WIREMOCK_PORT) {
 						                  "OffenceStartDate": "2005-09-02",
 						                  "OffenceEndDate": "2005-09-03",
                               "Description": "EMPTY TEMPLATE FOR USE WHERE A STANDARD OFFENCE WORDING IS NOT AVAILABLE",
+                              "MOJStatsCode": "195/99",
                               "code": "XX99001"
                             }
                           ]
@@ -199,6 +201,53 @@ class SDRSApiMockServer : WireMockServer(WIREMOCK_PORT) {
                     },                    
                     "MessageStatus": {
                       "status": "SUCCESS"
+                    }
+                  }
+              """.trimIndent()
+            )
+        )
+    )
+  }
+
+  fun stubGetAllOffencesForQHasNoCache() {
+    stubFor(
+      post("/cld_StandingDataReferenceService/service/sdrs/sdrs/sdrsApi")
+        .withRequestBody(matchingJsonPath("$.MessageHeader[?(@.MessageType == 'GetOffence')]"))
+        .withRequestBody(matchingJsonPath("$.MessageHeader[?(@.From == 'CONSUMER_APPLICATION')]"))
+        .withRequestBody(matchingJsonPath("$.MessageHeader[?(@.To == 'SDRS_AZURE')]"))
+        .withRequestBody(matchingJsonPath("$.MessageBody[?(@.GatewayOperationType.GetOffenceRequest.AllOffences == 'ALL')]"))
+        .withRequestBody(matchingJsonPath("$.MessageBody[?(@.GatewayOperationType.GetOffenceRequest.AlphaChar == 'Q')]"))
+        .willReturn(
+          aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(
+              """ {
+                    "MessageBody": {
+                      "GatewayOperationType": {
+                        "Acknowledgement": {
+                          "Ack": {
+                            "MessageStatus": "ERRORED",
+                            "MessageComment": "",
+                            "TimeStamp": 1650459143863
+                          }
+                        }
+		                  }
+	                  },
+                    "MessageHeader": {
+                      "MessageID": {
+                        "UUID": "7717d82c-9cc2-4983-acf1-0d42770e88bd",
+                        "RelatesTo": "df2200e6-241c-4642-b391-3d53299185cd"
+                      },
+                      "TimeStamp": "2022-03-01T15:00:00Z",
+                      "MessageType": "getOffence",
+                      "From": "SDRS_AZURE",
+                      "To": "CONSUMER_APPLICATION"
+                    },
+                    "MessageStatus": {
+                      "status": "ERRORED",
+                      "code": "SDRS-99918",
+                      "reason": " ",
+                      "detail": " "
                     }
                   }
               """.trimIndent()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSServiceIntTest.kt
@@ -55,6 +55,7 @@ class SDRSServiceIntTest : IntegrationTestBase() {
             revisionId = 410082,
             startDate = LocalDate.of(2013, 3, 1),
             endDate = LocalDate.of(2013, 3, 2),
+            homeOfficeStatsCode = "195/99",
             changedDate = null
           ),
         )
@@ -143,5 +144,30 @@ class SDRSServiceIntTest : IntegrationTestBase() {
           )
         )
       )
+  }
+
+  @Test
+  fun `Handle SDRS-99918 as a success ie no offences exist for that cache (cache doesnt exit)`() {
+    sdrsApiMockServer.stubGetAllOffencesReturnEmptyArray()
+    sdrsApiMockServer.stubGetAllOffencesForQHasNoCache()
+    sdrsService.loadAllOffences()
+    val offences = offenceRepository.findAll()
+    val statusRecords = sdrsLoadStatusRepository.findAll()
+    val statusHistoryRecords = sdrsLoadStatusHistoryRepository.findAll()
+
+    assertThat(offences).isEmpty()
+
+    assertThat(statusRecords.size).isEqualTo(26)
+    statusRecords.forEach {
+      println("Alpha char = " + it.alphaChar)
+      assertThat(it.status).isEqualTo(SUCCESS)
+      assertThat(it.loadType).isEqualTo(FULL_LOAD)
+    }
+
+    assertThat(statusHistoryRecords.size).isEqualTo(26)
+    statusHistoryRecords.forEach {
+      assertThat(it.status).isEqualTo(SUCCESS)
+      assertThat(it.loadType).isEqualTo(FULL_LOAD)
+    }
   }
 }


### PR DESCRIPTION
The no cache error from SDRS can be a false negative, in the sense that SDRS reports this error if there's no 'cache' but it, also reports this error if there are no offences for the passed in alphaChar (at the moment this happens with Q)

So treating this 'error' as a success. Will talk to SDRS about this - and revisit if they refactor their side.