### PR TITLE
OFFENCES-77 Add SYSTEM_CLIENT_ID and SYSTEM_CLIENT_SECRET namespace secret env var names for heml deploy

### DIFF
--- a/helm_deploy/manage-offences-api/values.yaml
+++ b/helm_deploy/manage-offences-api/values.yaml
@@ -31,6 +31,8 @@ generic-service:
   namespace_secrets:
     manage-offences-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
+      SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
+      SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
     rds-instance-output:
       DB_SERVER: "rds_instance_address"
       DB_NAME: "database_name"


### PR DESCRIPTION
Fixes the following error in dev
```
{
	"status": 500,
	"errorCode": null,
	"userMessage": "Unexpected error: [invalid_token_response] An error occurred while attempting to retrieve the OAuth 2.0 Access Token Response: 401 : [no body]",
	"developerMessage": "[invalid_token_response] An error occurred while attempting to retrieve the OAuth 2.0 Access Token Response: 401 : [no body]",
	"moreInfo": null
}
```