### PR TITLE
OFFENCES-82 Change batch size to 1 when posting to prison-api - workaround for Azure WAF firewall rule (Mandatory rule. Cannot be disabled. Inbound Anomaly Score Exceeded)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/OffenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/OffenceService.kt
@@ -204,6 +204,6 @@ class OffenceService(
 
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
-    private const val MAX_RECORDS_IN_POST_PAYLOAD = 100
+    private const val MAX_RECORDS_IN_POST_PAYLOAD = 1
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/OffencesControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/OffencesControllerIntTest.kt
@@ -127,14 +127,20 @@ class OffencesControllerIntTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isOk
 
-    prisonApiMockServer.verify(
-      WireMock.postRequestedFor(WireMock.urlEqualTo("/api/offences/offence"))
-        .withRequestBody(equalToJson(FULL_SYNC_CREATE_OFFENCES, true, true))
-    )
+    verifyPostOffenceToPrisonApi(FULL_SYNC_CREATE_OFFENCES_AF06999)
+    verifyPostOffenceToPrisonApi(FULL_SYNC_CREATE_OFFENCES_AB14001)
+    verifyPostOffenceToPrisonApi(FULL_SYNC_CREATE_OFFENCES_AB14002)
+    verifyPostOffenceToPrisonApi(FULL_SYNC_CREATE_OFFENCES_AB14003)
   }
 
+  private fun verifyPostOffenceToPrisonApi(json: String) =
+    prisonApiMockServer.verify(
+      WireMock.postRequestedFor(WireMock.urlEqualTo("/api/offences/offence"))
+        .withRequestBody(equalToJson(json, true, true))
+    )
+
   companion object {
-    private val FULL_SYNC_CREATE_OFFENCES = """
+    private val FULL_SYNC_CREATE_OFFENCES_AF06999 = """
       [
        {
           "code" : "AF06999",
@@ -150,7 +156,11 @@ class OffencesControllerIntTest : IntegrationTestBase() {
           "activeFlag" : "Y",
           "listSequence" : null,
           "expiryDate" : null
-        }, 
+        }
+    ] 
+    """.trimIndent()
+    private val FULL_SYNC_CREATE_OFFENCES_AB14001 = """
+      [
         {
           "code" : "AB14001",
           "description" : "Fail to comply with an animal by-product requirement",
@@ -165,7 +175,11 @@ class OffencesControllerIntTest : IntegrationTestBase() {
           "activeFlag" : "Y",
           "listSequence" : null,
           "expiryDate" : null
-        }, 
+        }
+    ] 
+    """.trimIndent()
+    private val FULL_SYNC_CREATE_OFFENCES_AB14002 = """
+      [     
         {
           "code" : "AB14002",
           "description" : "Intentionally obstruct an authorised person",
@@ -180,7 +194,11 @@ class OffencesControllerIntTest : IntegrationTestBase() {
           "activeFlag" : "Y",
           "listSequence" : null,
           "expiryDate" : null
-        }, 
+        } 
+    ] 
+    """.trimIndent()
+    private val FULL_SYNC_CREATE_OFFENCES_AB14003 = """
+      [ 
         {
           "code" : "AB14003",
           "description" : "CJS Title Fail to give to an authorised person information / assistance / provide facilities that person may require",


### PR DESCRIPTION
An exception rule was put in to the Azure WAF firewall to ignore the description fields, however if we batch multiple offences that break the same rule then another mandatory WAF firewall rule fails

`Mandatory rule. Cannot be disabled. Inbound Anomaly Score Exceeded (Total Score: 50)`
            
This commit is a workaround - will look into the possibility of excluding this rule so that we can send batches