### PR TITLE
OFFENCES-84 Add delta sync functionality to NOMIS, add toggling capability to turn features on/off through api calls, add schedule for full NOMIS sync

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/entity/FeatureToggle.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/entity/FeatureToggle.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.entity
+
+import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.Feature
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Entity
+@Table
+data class FeatureToggle(
+  @Id
+  @Enumerated(EnumType.STRING)
+  val feature: Feature,
+  val enabled: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/enum/Feature.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/enum/Feature.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.enum
+
+enum class Feature {
+  FULL_SYNC_NOMIS,
+  DELTA_SYNC_NOMIS,
+  SYNC_SDRS,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/FeatureToggle.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/FeatureToggle.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.Feature
+
+@Schema(description = "Feature toggle details")
+data class FeatureToggle(
+  @Schema(description = "Feature to be toggled: FULL_SYNC_NOMIS, DELTA_SYNC_NOMIS or SYNC_SDRS")
+  val feature: Feature,
+  @Schema(description = "true or false - depending on whether the feature should be enabled")
+  val enabled: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/repository/FeatureToggleRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/repository/FeatureToggleRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.FeatureToggle
+import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.Feature
+
+@Repository
+interface FeatureToggleRepository : JpaRepository<FeatureToggle, Feature>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/AdminController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/AdminController.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.FeatureToggle
+import uk.gov.justice.digital.hmpps.manageoffencesapi.service.AdminService
+
+@RestController
+@RequestMapping("/admin", produces = [MediaType.APPLICATION_JSON_VALUE])
+class AdminController(
+  private val adminService: AdminService,
+) {
+  @PutMapping(value = ["/toggle-feature"])
+  @Operation(
+    summary = "Enable / disable a feature"
+  )
+  fun toggleFeature(@RequestBody featureToggle: FeatureToggle) {
+    log.info("Request received to toggle Feature to {}", featureToggle.enabled)
+    return adminService.toggleFeature(featureToggle)
+  }
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/OffenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/OffenceController.kt
@@ -7,20 +7,17 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.MostRecentLoadResult
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.Offence
 import uk.gov.justice.digital.hmpps.manageoffencesapi.service.OffenceService
-import uk.gov.justice.digital.hmpps.manageoffencesapi.service.SDRSService
 
 @RestController
 @RequestMapping("/offences", produces = [MediaType.APPLICATION_JSON_VALUE])
 class OffenceController(
-  private val offenceService: OffenceService,
-  private val sdrsService: SDRSService
+  private val offenceService: OffenceService
 ) {
   @GetMapping(value = ["/code/{offenceCode}"])
   @ResponseBody
@@ -46,17 +43,6 @@ class OffenceController(
   fun findLoadResults(): List<MostRecentLoadResult> {
     log.info("Request received to find the most recent load results")
     return offenceService.findLoadResults()
-  }
-
-  @PostMapping(value = ["/full-sync-nomis"])
-  @ResponseBody
-  @Operation(
-    summary = "Synchronise all offences with NOMIS",
-    description = "Synchronise all offences with NOMIS"
-  )
-  fun fullySyncWithNomis() {
-    log.info("Request received to synchronise with NOMIS")
-    return offenceService.fullSyncWithNomis()
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminService.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.service
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.Feature
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.FeatureToggle
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.FeatureToggleRepository
+
+@Service
+class AdminService(
+  private val featureToggleRepository: FeatureToggleRepository,
+) {
+  @Transactional
+  fun toggleFeature(featureToggle: FeatureToggle) {
+    featureToggleRepository.findById(featureToggle.feature)
+      .ifPresent { featureToggleRepository.save(it.copy(enabled = featureToggle.enabled)) }
+  }
+
+  @Transactional(readOnly = true)
+  fun isFeatureEnabled(feature: Feature): Boolean =
+    featureToggleRepository.findById(feature).map { it.enabled }.orElse(false)
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
   application:
     name: manage-offences-api
   codec:
-    max-in-memory-size: 10MB
+    max-in-memory-size: 15MB
 
   jackson:
     date-format: "yyyy-MM-dd HH:mm:ss"

--- a/src/main/resources/migration/common/V6__feature_toggle.sql
+++ b/src/main/resources/migration/common/V6__feature_toggle.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS feature_toggle (
+    feature VARCHAR(32),
+    enabled BOOLEAN,
+    PRIMARY KEY (feature)
+);
+
+INSERT INTO feature_toggle (feature, enabled) VALUES ('FULL_SYNC_NOMIS', false);
+INSERT INTO feature_toggle (feature, enabled) VALUES ('DELTA_SYNC_NOMIS', false);
+INSERT INTO feature_toggle (feature, enabled) VALUES ('SYNC_SDRS', false);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/AdminServiceTest.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.service
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.Feature.FULL_SYNC_NOMIS
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.FeatureToggle
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.FeatureToggleRepository
+import java.util.Optional
+import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.FeatureToggle as FeatureToggleEntity
+
+class AdminServiceTest {
+  private val featureToggleRepository = mock<FeatureToggleRepository>()
+
+  private val adminService = AdminService(featureToggleRepository)
+
+  @Test
+  fun `If the feature doesnt exist then no save is performed`() {
+    whenever(featureToggleRepository.findById(FULL_SYNC_NOMIS)).thenReturn(Optional.empty())
+
+    adminService.toggleFeature(FeatureToggle(FULL_SYNC_NOMIS, true))
+
+    verify(featureToggleRepository, times(1)).findById(FULL_SYNC_NOMIS)
+    verifyNoMoreInteractions(featureToggleRepository)
+  }
+
+  @Test
+  fun `Toggling a feature gets saved`() {
+    whenever(featureToggleRepository.findById(FULL_SYNC_NOMIS)).thenReturn(Optional.of(FeatureToggleEntity(FULL_SYNC_NOMIS, false)))
+
+    adminService.toggleFeature(FeatureToggle(FULL_SYNC_NOMIS, true))
+
+    verify(featureToggleRepository, times(1)).save(FeatureToggleEntity(FULL_SYNC_NOMIS, true))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/OffenceServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/OffenceServiceIntTest.kt
@@ -1,0 +1,121 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.service
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.jdbc.Sql
+import uk.gov.justice.digital.hmpps.manageoffencesapi.integration.IntegrationTestBase
+
+class OffenceServiceIntTest : IntegrationTestBase() {
+  @Autowired
+  lateinit var offenceService: OffenceService
+
+  @Test
+  @Sql(
+    "classpath:test_data/reset-all-data.sql",
+    "classpath:test_data/insert-offence-data.sql",
+    "classpath:test_data/insert-offence-data-that-exists-in-nomis.sql"
+  )
+  fun `Fully sync with NOMIS - includes creating statute and ho-code`() {
+    ('A'..'Z').forEach { alphaChar ->
+      prisonApiMockServer.stubFindByOffenceCodeStartsWithReturnsNothing(alphaChar)
+    }
+    prisonApiMockServer.stubFindByOffenceCodeStartsWith('M')
+    prisonApiMockServer.stubCreateHomeOfficeCode()
+    prisonApiMockServer.stubCreateStatute()
+    prisonApiMockServer.stubCreateOffence()
+    prisonApiMockServer.stubUpdateOffence()
+
+    offenceService.fullSyncWithNomis()
+
+    verifyPostOffenceToPrisonApi(FULL_SYNC_CREATE_OFFENCES_AF06999)
+    verifyPostOffenceToPrisonApi(FULL_SYNC_CREATE_OFFENCES_AB14001)
+    verifyPostOffenceToPrisonApi(FULL_SYNC_CREATE_OFFENCES_AB14002)
+    verifyPostOffenceToPrisonApi(FULL_SYNC_CREATE_OFFENCES_AB14003)
+  }
+
+  private fun verifyPostOffenceToPrisonApi(json: String) =
+    prisonApiMockServer.verify(
+      WireMock.postRequestedFor(WireMock.urlEqualTo("/api/offences/offence"))
+        .withRequestBody(WireMock.equalToJson(json, true, true))
+    )
+
+  companion object {
+    private val FULL_SYNC_CREATE_OFFENCES_AF06999 = """
+      [
+       {
+          "code" : "AF06999",
+          "description" : "Brought before the court as being absent without leave from the Armed Forces",
+          "statuteCode" : {
+            "code" : "AF06",
+            "description" : "Contrary to section 19 of the Zoo Licensing Act 1981",
+            "legislatingBodyCode" : "UK",
+            "activeFlag" : "Y"
+            },
+          "hoCode" : null,
+          "severityRanking" : "99",
+          "activeFlag" : "Y",
+          "listSequence" : null,
+          "expiryDate" : null
+        }
+    ] 
+    """.trimIndent()
+    private val FULL_SYNC_CREATE_OFFENCES_AB14001 = """
+      [
+        {
+          "code" : "AB14001",
+          "description" : "Fail to comply with an animal by-product requirement",
+          "statuteCode" : {
+            "code" : "AB14",
+            "description" : "AB14",
+            "legislatingBodyCode" : "UK",
+            "activeFlag" : "Y"
+          },
+          "hoCode" : null,
+          "severityRanking" : "99",
+          "activeFlag" : "Y",
+          "listSequence" : null,
+          "expiryDate" : null
+        }
+    ] 
+    """.trimIndent()
+    private val FULL_SYNC_CREATE_OFFENCES_AB14002 = """
+      [     
+        {
+          "code" : "AB14002",
+          "description" : "Intentionally obstruct an authorised person",
+          "statuteCode" : {
+            "code" : "AB14",
+            "description" : "AB14",
+            "legislatingBodyCode" : "UK",
+            "activeFlag" : "Y"
+          },
+          "hoCode" : null,
+          "severityRanking" : "99",
+          "activeFlag" : "Y",
+          "listSequence" : null,
+          "expiryDate" : null
+        } 
+    ] 
+    """.trimIndent()
+    private val FULL_SYNC_CREATE_OFFENCES_AB14003 = """
+      [ 
+        {
+          "code" : "AB14003",
+          "description" : "CJS Title Fail to give to an authorised person information / assistance / provide facilities that person may require",
+          "statuteCode" : {
+            "code" : "AB14",
+            "description" : "AB14",
+            "legislatingBodyCode" : "UK",
+            "activeFlag" : "Y"
+          },
+          "hoCode" : null,
+          "severityRanking" : "99",
+          "activeFlag" : "Y",
+          "listSequence" : null,
+          "expiryDate" : null
+        } 
+    ] 
+    """.trimIndent()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSServiceIntTest.kt
@@ -30,7 +30,7 @@ class SDRSServiceIntTest : IntegrationTestBase() {
 
   @Test
   @Sql(
-    "classpath:test_data/clear-all-data.sql"
+    "classpath:test_data/reset-all-data.sql"
   )
   fun `Perform a full load of offences retrieved from SDRS`() {
     sdrsApiMockServer.stubGetAllOffencesReturnEmptyArray()
@@ -73,7 +73,7 @@ class SDRSServiceIntTest : IntegrationTestBase() {
 
   @Test
   @Sql(
-    "classpath:test_data/clear-all-data.sql",
+    "classpath:test_data/reset-all-data.sql",
     "classpath:test_data/insert-sdrs-load-result.sql",
   )
   fun `Update any offences that have changed`() {
@@ -118,9 +118,9 @@ class SDRSServiceIntTest : IntegrationTestBase() {
 
   @Test
   @Sql(
-    "classpath:test_data/clear-all-data.sql",
+    "classpath:test_data/reset-all-data.sql",
   )
-  fun `Handle SDRS-99918 as a success ie no offences exist for that cache (cache doesnt exit)`() {
+  fun `Handle SDRS-99918 as a success ie no offences exist for that cache (cache doesnt exist)`() {
     sdrsApiMockServer.stubGetAllOffencesReturnEmptyArray()
     sdrsApiMockServer.stubGetAllOffencesForQHasNoCache()
     sdrsApiMockServer.stubControlTableRequest()
@@ -147,7 +147,7 @@ class SDRSServiceIntTest : IntegrationTestBase() {
 
   @Test
   @Sql(
-    "classpath:test_data/clear-all-data.sql",
+    "classpath:test_data/reset-all-data.sql",
     "classpath:test_data/insert-sdrs-load-result.sql",
   )
   fun `Handle unexpected exception from SDRS - Bad JSON is returned from SDRS thus causing a generic exception`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSServiceTest.kt
@@ -1,0 +1,112 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.service
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.SdrsLoadResult
+import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.Feature.DELTA_SYNC_NOMIS
+import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.Feature.SYNC_SDRS
+import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.LoadStatus.SUCCESS
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.external.sdrs.ControlTableRecord
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.external.sdrs.GatewayOperationTypeResponse
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.external.sdrs.GetControlTableResponse
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.external.sdrs.MessageBodyResponse
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.external.sdrs.MessageStatusResponse
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.external.sdrs.SDRSResponse
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceRepository
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.SdrsLoadResultHistoryRepository
+import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.SdrsLoadResultRepository
+import java.time.LocalDateTime
+import java.util.Optional
+
+class SDRSServiceTest {
+  private val offenceRepository = mock<OffenceRepository>()
+  private val sdrsLoadResultRepository = mock<SdrsLoadResultRepository>()
+  private val sdrsLoadResultHistoryRepository = mock<SdrsLoadResultHistoryRepository>()
+  private val adminService = mock<AdminService>()
+  private val offenceService = mock<OffenceService>()
+  private val sdrsApiClient = mock<SDRSApiClient>()
+
+  private val sdrsService = SDRSService(
+    sdrsApiClient,
+    offenceRepository,
+    sdrsLoadResultRepository,
+    sdrsLoadResultHistoryRepository,
+    offenceService,
+    adminService
+  )
+
+  @BeforeEach
+  fun setup() {
+    ('A'..'Z').forEach { alphaChar ->
+      whenever(sdrsLoadResultRepository.findById(alphaChar.toString())).thenReturn(
+        Optional.of(
+          SdrsLoadResult(
+            alphaChar = alphaChar.toString(),
+            status = SUCCESS,
+            lastSuccessfulLoadDate = NOW
+          )
+        )
+      )
+    }
+    val loadResults = ('A'..'Z').map { alphaChar ->
+      SdrsLoadResult(
+        alphaChar = alphaChar.toString(),
+        status = SUCCESS,
+        lastSuccessfulLoadDate = NOW
+      )
+    }
+
+    whenever(sdrsLoadResultRepository.findAll()).thenReturn(loadResults)
+    whenever(adminService.isFeatureEnabled(SYNC_SDRS)).thenReturn(true)
+    whenever(adminService.isFeatureEnabled(DELTA_SYNC_NOMIS)).thenReturn(true)
+  }
+
+  @Test
+  fun `Ensure sync with SDRS doesnt occur if associated feature toggle is disabled`() {
+    whenever(adminService.isFeatureEnabled(SYNC_SDRS)).thenReturn(false)
+
+    sdrsService.synchroniseWithSdrs()
+
+    verifyNoInteractions(sdrsApiClient)
+  }
+
+  @Test
+  fun `Ensure delta sync with nomis is called for only the alphaChar affected (there are records to update for A) `() {
+    whenever(sdrsApiClient.callSDRS(any())).thenReturn(CONTROL_TABLE_RESPONSE)
+
+    sdrsService.synchroniseWithSdrs()
+
+    verify(offenceService, times(1)).fullySyncOffenceGroupWithNomis("A")
+  }
+
+  @Test
+  fun `Ensure delta sync with nomis doesnt occur if associated feature toggle is disabled`() {
+    whenever(sdrsApiClient.callSDRS(any())).thenReturn(CONTROL_TABLE_RESPONSE)
+    whenever(adminService.isFeatureEnabled(DELTA_SYNC_NOMIS)).thenReturn(false)
+
+    sdrsService.synchroniseWithSdrs()
+
+    verifyNoInteractions(offenceService)
+  }
+
+  companion object {
+    private val NOW = LocalDateTime.now()
+
+    private val CONTROL_TABLE_RESPONSE = SDRSResponse(
+      messageBody = MessageBodyResponse(
+        gatewayOperationType = GatewayOperationTypeResponse(
+          getControlTableResponse = GetControlTableResponse(
+            referenceDataSet = listOf(ControlTableRecord("offence_A", lastUpdate = NOW))
+          )
+        ),
+      ),
+      messageStatus = MessageStatusResponse(status = "SUCCESS")
+    )
+  }
+}

--- a/src/test/resources/test_data/reset-all-data.sql
+++ b/src/test/resources/test_data/reset-all-data.sql
@@ -2,3 +2,5 @@ DELETE from offence;
 DELETE from sdrs_load_result_history;
 
 UPDATE sdrs_load_result SET status = NULL, load_type = NULL, load_date = NULL, last_successful_load_date = NULL;
+UPDATE feature_toggle set enabled = true;
+


### PR DESCRIPTION
- add a schedule to run full sync to NOMIS (every hour) - however will only run if the the toggle is enabled
- Three feature toggles added
1. FULL_SYNC_NOMIS
2. DELTA_SYNC_NOMIS (runs after the sync from SDRS - as part of the same job))
3. SYNC_SDRS