### PR TITLE
OFFENCES-97 Only sync with nomis if the sync with sdrs succeeds; i.e if the sync with sdrs failed do not sync with nomis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:18-slim AS builder
+FROM eclipse-temurin:18-jre-jammy AS builder
 
 ARG BUILD_NUMBER
 ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
@@ -7,7 +7,7 @@ WORKDIR /app
 ADD . .
 RUN ./gradlew assemble -Dorg.gradle.daemon=false
 
-FROM openjdk:18-slim
+FROM eclipse-temurin:18-jre-jammy
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 ARG BUILD_NUMBER

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSService.kt
@@ -135,8 +135,7 @@ class SDRSService(
         log.info("Caches to update are {}", cachesToUpdate)
         val deltaSyncToNomisEnabled = adminService.isFeatureEnabled(DELTA_SYNC_NOMIS)
         cachesToUpdate.forEach { alphaChar ->
-          updateSingleCache(alphaChar, lastSuccessfulLoadDate, loadDate)
-          if (deltaSyncToNomisEnabled) offenceService.fullySyncOffenceGroupWithNomis(alphaChar.toString())
+          updateSingleCache(alphaChar, lastSuccessfulLoadDate, loadDate, deltaSyncToNomisEnabled)
         }
       }
     }
@@ -145,7 +144,8 @@ class SDRSService(
   private fun updateSingleCache(
     alphaChar: Char,
     lastLoadDate: LocalDateTime,
-    loadDate: LocalDateTime?
+    loadDate: LocalDateTime?,
+    deltaSyncToNomisEnabled: Boolean
   ) {
     log.info("Starting update load for alpha char {} ", alphaChar)
     try {
@@ -161,6 +161,7 @@ class SDRSService(
           )
         }
         saveLoad(alphaChar, loadDate, SUCCESS, UPDATE)
+        if (deltaSyncToNomisEnabled) offenceService.fullySyncOffenceGroupWithNomis(alphaChar.toString())
       }
     } catch (e: Exception) {
       log.error("Failed for updating a single cache from SDRS for alphaChar {} - error message = {}", alphaChar, e.message)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSServiceIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/SDRSServiceIntTest.kt
@@ -80,7 +80,12 @@ class SDRSServiceIntTest : IntegrationTestBase() {
     sdrsApiMockServer.stubGetAllOffencesReturnEmptyArray()
     sdrsApiMockServer.stubGetChangedOffencesForA()
     sdrsApiMockServer.stubControlTableRequest()
+    ('A'..'Z').forEach { alphaChar ->
+      prisonApiMockServer.stubFindByOffenceCodeStartsWithReturnsNothing(alphaChar)
+    }
+
     sdrsService.synchroniseWithSdrs()
+
     val offences = offenceRepository.findAll()
     val statusRecords = sdrsLoadResultRepository.findAll()
     val statusHistoryRecords = sdrsLoadResultHistoryRepository.findAll()


### PR DESCRIPTION
+ Change docker image to use eclipse-temurin as the open-jdk image is being deprecated