### PR TITLE
OFFENCES-99 temporarily disable veracode scan until it supports JDK 18 and kotlin 1.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,11 +106,12 @@ workflows:
           slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars
-      - hmpps/veracode_pipeline_scan:
-          slack_channel: << pipeline.parameters.alerts-slack-channel >>
-          context:
-            - veracode-credentials
-            - hmpps-common-vars
+#      currently disabled as no support for jdk 18 or kotlin 1.7
+#      - hmpps/veracode_pipeline_scan:
+#          slack_channel: << pipeline.parameters.alerts-slack-channel >>
+#          context:
+#            - veracode-credentials
+#            - hmpps-common-vars
   security-weekly:
     triggers:
       - schedule:


### PR DESCRIPTION
Discussion ongoing here:
https://mojdt.slack.com/archives/C01S1M82NQ1/p1655992793136369?thread_ts=1655984952.595619&cid=C01S1M82NQ1