### PR TITLE
OFFENCES-108 Add parent-child relationship to offences to cater for inchoate offences (eg AB00001 and AB00001A)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/entity/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/entity/Offence.kt
@@ -23,6 +23,7 @@ data class Offence(
   val category: Int? = null,
   val subCategory: Int? = null,
   val actsAndSections: String? = null,
+  val parentOffenceId: Long? = null,
   val changedDate: LocalDateTime? = null,
   val createdDate: LocalDateTime = LocalDateTime.now(),
   val lastUpdatedDate: LocalDateTime = LocalDateTime.now(),
@@ -47,5 +48,11 @@ data class Offence(
     get() {
       if (endDate == null || endDate.isAfter(LocalDate.now())) return "Y"
       return "N"
+    }
+
+  val parentCode: String?
+    get() {
+      if (code.length < 8) return null
+      return code.substring(0, 7)
     }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/repository/OffenceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/repository/OffenceRepository.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.manageoffencesapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.Offence
 import java.util.Optional
@@ -9,4 +10,7 @@ import java.util.Optional
 interface OffenceRepository : JpaRepository<Offence, Long> {
   fun findByCodeStartsWithIgnoreCase(code: String): List<Offence>
   fun findOneByCode(code: String): Optional<Offence>
+
+  @Query("SELECT o FROM Offence o WHERE o.code LIKE :alphaChar% AND LENGTH(o.code) > 7 AND o.parentOffenceId IS NULL")
+  fun findChildOffencesWithNoParent(alphaChar: Char): List<Offence>
 }

--- a/src/main/resources/migration/common/V10__add_parent_id_to_offence.sql
+++ b/src/main/resources/migration/common/V10__add_parent_id_to_offence.sql
@@ -1,0 +1,5 @@
+ALTER TABLE offence ADD COLUMN parent_offence_id INT;
+ALTER TABLE offence ADD CONSTRAINT fk_offence_to_parent_offence FOREIGN KEY (parent_offence_id) REFERENCES offence (id);
+
+UPDATE offence o set parent_offence_id = (SELECT id FROM offence o2 WHERE o2.code = SUBSTRING(o.code, 1, 7))
+WHERE length(o.code) > 7;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/integration/wiremock/SDRSApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/integration/wiremock/SDRSApiMockServer.kt
@@ -13,22 +13,8 @@ class SDRSApiMockServer : WireMockServer(WIREMOCK_PORT) {
   }
 
   fun stubGetAllOffencesForA() {
-    stubFor(
-      post("/cld_StandingDataReferenceService/service/sdrs/sdrs/sdrsApi")
-        .withRequestBody(matchingJsonPath("$.MessageHeader[?(@.MessageType == 'GetOffence')]"))
-        .withRequestBody(matchingJsonPath("$.MessageHeader[?(@.From == 'CONSUMER_APPLICATION')]"))
-        .withRequestBody(matchingJsonPath("$.MessageHeader[?(@.To == 'SDRS_AZURE')]"))
-        .withRequestBody(matchingJsonPath("$.MessageBody[?(@.GatewayOperationType.GetOffenceRequest.AllOffences == 'ALL')]"))
-        .withRequestBody(matchingJsonPath("$.MessageBody[?(@.GatewayOperationType.GetOffenceRequest.AlphaChar == 'A')]"))
-        .willReturn(
-          aResponse()
-            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
-            .withBody(
-              """ {
-                    "MessageBody": {
-                      "GatewayOperationType": {
-                        "GetOffenceResponse": {
-                          "Offence": [
+    getAllOffences(
+      """
                             {
                               "OffenceRevisionId": 410082,
                               "OffenceStartDate": "2013-03-01",
@@ -44,52 +30,13 @@ class SDRSApiMockServer : WireMockServer(WIREMOCK_PORT) {
                               "Description": "EMPTY TEMPLATE FOR USE WHERE A STANDARD OFFENCE WORDING IS NOT AVAILABLE",
                               "MOJStatsCode": "195/99",
                               "code": "XX99001"
-                            }
-                          ]
-                        }
-		                  }
-	                  },
-                    "MessageHeader": {
-                      "MessageID": {
-                        "UUID": "7717d82c-9cc2-4983-acf1-0d42770e88bd",
-                        "RelatesTo": "df2200e6-241c-4642-b391-3d53299185cd"
-                      },
-                      "TimeStamp": "2022-03-01T15:00:00Z",
-                      "MessageType": "getOffence",
-                      "From": "SDRS_AZURE",
-                      "To": "CONSUMER_APPLICATION"
-                    },
-                    "MessageStatus": {
-                      "status": "SUCCESS",
-                      "code": " ",
-                      "reason": " ",
-                      "detail": " "
-                    }
-                  }
-              """.trimIndent()
-            )
-        )
+                            }"""
     )
   }
 
   fun stubGetAllOffencesForAMultipleOffences() {
-    stubFor(
-      post("/cld_StandingDataReferenceService/service/sdrs/sdrs/sdrsApi")
-        .withRequestBody(matchingJsonPath("$.MessageHeader[?(@.MessageType == 'GetOffence')]"))
-        .withRequestBody(matchingJsonPath("$.MessageHeader[?(@.From == 'CONSUMER_APPLICATION')]"))
-        .withRequestBody(matchingJsonPath("$.MessageHeader[?(@.To == 'SDRS_AZURE')]"))
-        .withRequestBody(matchingJsonPath("$.MessageBody[?(@.GatewayOperationType.GetOffenceRequest.AllOffences == 'ALL')]"))
-        .withRequestBody(matchingJsonPath("$.MessageBody[?(@.GatewayOperationType.GetOffenceRequest.AlphaChar == 'A')]"))
-        .willReturn(
-          aResponse()
-            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
-            .withBody(
-              """ {
-                    "MessageBody": {
-                      "GatewayOperationType": {
-                        "GetOffenceResponse": {
-                          "Offence": [
-                            {
+    getAllOffences(
+      """{
                               "OffenceRevisionId": 410082,
                               "OffenceStartDate": "2013-03-01",
 						                  "OffenceEndDate": "2013-03-02",
@@ -112,31 +59,52 @@ class SDRSApiMockServer : WireMockServer(WIREMOCK_PORT) {
                               "Description": "EMPTY TEMPLATE FOR USE WHERE A STANDARD OFFENCE WORDING IS NOT AVAILABLE",
                               "MOJStatsCode": "195/99",
                               "code": "XX99002"
-                            }
-                          ]
-                        }
-		                  }
-	                  },
-                    "MessageHeader": {
-                      "MessageID": {
-                        "UUID": "7717d82c-9cc2-4983-acf1-0d42770e88bd",
-                        "RelatesTo": "df2200e6-241c-4642-b391-3d53299185cd"
-                      },
-                      "TimeStamp": "2022-03-01T15:00:00Z",
-                      "MessageType": "getOffence",
-                      "From": "SDRS_AZURE",
-                      "To": "CONSUMER_APPLICATION"
-                    },
-                    "MessageStatus": {
-                      "status": "SUCCESS",
-                      "code": " ",
-                      "reason": " ",
-                      "detail": " "
-                    }
-                  }
-              """.trimIndent()
-            )
-        )
+                            }"""
+    )
+  }
+
+  fun stubGetAllOffencesWithChildren() {
+    getAllOffences(
+      """{
+                                "OffenceRevisionId": 410082,
+                                "OffenceStartDate": "2013-03-01",
+                                "OffenceEndDate": "2013-03-02",
+                                "Description": "EMPTY TEMPLATE FOR USE WHERE A STANDARD OFFENCE WORDING IS NOT AVAILABLE",
+                                "MOJStatsCode": "195/99",
+                                "code": "AX99001A"
+                              },
+                              {
+                                "OffenceRevisionId": 354116,
+                                "OffenceStartDate": "2005-09-02",
+                                "OffenceEndDate": "2005-09-03",
+                                "Description": "EMPTY TEMPLATE FOR USE WHERE A STANDARD OFFENCE WORDING IS NOT AVAILABLE",
+                                "MOJStatsCode": "195/99",
+                                "code": "AX99001"
+                              },
+                              {
+                                "OffenceRevisionId": 410082,
+                                "OffenceStartDate": "2013-03-01",
+                                "OffenceEndDate": "2013-03-02",
+                                "Description": "EMPTY TEMPLATE FOR USE WHERE A STANDARD OFFENCE WORDING IS NOT AVAILABLE",
+                                "MOJStatsCode": "195/99",
+                                "code": "AX99001B"
+                              },
+                              {
+                                "OffenceRevisionId": 410082,
+                                "OffenceStartDate": "2013-03-01",
+                                "OffenceEndDate": "2013-03-02",
+                                "Description": "EMPTY TEMPLATE FOR USE WHERE A STANDARD OFFENCE WORDING IS NOT AVAILABLE",
+                                "MOJStatsCode": "195/99",
+                                "code": "AX99002"
+                              },
+                              {
+                                "OffenceRevisionId": 410082,
+                                "OffenceStartDate": "2013-03-01",
+                                "OffenceEndDate": "2013-03-02",
+                                "Description": "EMPTY TEMPLATE FOR USE WHERE A STANDARD OFFENCE WORDING IS NOT AVAILABLE",
+                                "MOJStatsCode": "195/99",
+                                "code": "AX99003B"
+                              }"""
     )
   }
 
@@ -376,6 +344,51 @@ class SDRSApiMockServer : WireMockServer(WIREMOCK_PORT) {
                       "detail": " "
                     }
                   }
+              """.trimIndent()
+            )
+        )
+    )
+  }
+
+  private fun getAllOffences(offences: String, alphaChar: Char = 'A') {
+    stubFor(
+      post("/cld_StandingDataReferenceService/service/sdrs/sdrs/sdrsApi")
+        .withRequestBody(matchingJsonPath("$.MessageHeader[?(@.MessageType == 'GetOffence')]"))
+        .withRequestBody(matchingJsonPath("$.MessageHeader[?(@.From == 'CONSUMER_APPLICATION')]"))
+        .withRequestBody(matchingJsonPath("$.MessageHeader[?(@.To == 'SDRS_AZURE')]"))
+        .withRequestBody(matchingJsonPath("$.MessageBody[?(@.GatewayOperationType.GetOffenceRequest.AllOffences == 'ALL')]"))
+        .withRequestBody(matchingJsonPath("$.MessageBody[?(@.GatewayOperationType.GetOffenceRequest.AlphaChar == 'A')]"))
+        .willReturn(
+          aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(
+              """ {
+                      "MessageBody": {
+                        "GatewayOperationType": {
+                          "GetOffenceResponse": {
+                            "Offence": [
+                              $offences
+                            ]
+                          }
+                        }
+                      },
+                      "MessageHeader": {
+                        "MessageID": {
+                          "UUID": "7717d82c-9cc2-4983-acf1-0d42770e88bd",
+                          "RelatesTo": "df2200e6-241c-4642-b391-3d53299185cd"
+                        },
+                        "TimeStamp": "2022-03-01T15:00:00Z",
+                        "MessageType": "getOffence",
+                        "From": "SDRS_AZURE",
+                        "To": "CONSUMER_APPLICATION"
+                      },
+                      "MessageStatus": {
+                        "status": "SUCCESS",
+                        "code": " ",
+                        "reason": " ",
+                        "detail": " "
+                      }
+                    }
               """.trimIndent()
             )
         )

--- a/src/test/resources/test_data/set-success-all-load-results.sql
+++ b/src/test/resources/test_data/set-success-all-load-results.sql
@@ -1,0 +1,1 @@
+UPDATE sdrs_load_result SET status = 'SUCCESS', load_type = 'FULL_LOAD', load_date = '2022-04-19 22:49:47.797084+01', last_successful_load_date = '2022-04-19 22:49:47.797084+01';


### PR DESCRIPTION
Creates the relationship and also populates any children with their parent during an SDRS update or full load

TODO 
- Expose the parent/child relationship in the domain object  (at the moment only in the entity)
- Consider the UI and how this relationship will be displayed