### PR TITLE
OFFENCES-108 Add parent/child details to the Offence domain object. When linking/unlinking offences automatically link/unlink any children

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/Offence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/Offence.kt
@@ -28,4 +28,10 @@ data class Offence(
   val loadDate: LocalDateTime? = null,
   @Schema(description = "The schedules linked to this offence")
   val schedules: List<ScheduleDetails>? = emptyList(),
+  @Schema(description = "If true then this is a inchoate offence; i.e. a child of another offence")
+  val isChild: Boolean = false,
+  @Schema(description = "The parent offence id of an inchoate offence")
+  val parentOffenceId: Long? = null,
+  @Schema(description = "A list of child offence ID's; i.e. inchoate offences linked to this offence")
+  val childOffenceIds: List<Long>? = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/repository/OffenceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/repository/OffenceRepository.kt
@@ -13,4 +13,8 @@ interface OffenceRepository : JpaRepository<Offence, Long> {
 
   @Query("SELECT o FROM Offence o WHERE o.code LIKE :alphaChar% AND LENGTH(o.code) > 7 AND o.parentOffenceId IS NULL")
   fun findChildOffencesWithNoParent(alphaChar: Char): List<Offence>
+
+  fun findByParentOffenceId(parentOffenceId: Long): List<Offence>
+
+  fun findByParentOffenceIdIn(parentOffenceIds: List<Long>): List<Offence>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleController.kt
@@ -31,7 +31,7 @@ class ScheduleController(
 
   @PostMapping(value = ["/link-offences/{schedulePartId}"])
   @Operation(
-    summary = "Link offences to a schedule part"
+    summary = "Link offences to a schedule part - will also link any associated inchoate offences (i.e. if any of the passed in offences have children they will also be linked)"
   )
   fun linkOffences(
     @Parameter(required = true, example = "1000011", description = "The schedule part ID")
@@ -45,7 +45,7 @@ class ScheduleController(
 
   @PostMapping(value = ["/unlink-offences"])
   @Operation(
-    summary = "Unlink offences from schedules"
+    summary = "Unlink offences from schedules - will also unlink any associated inchoate offences (i.e. if any of the passed in offences have children they will also be unlinked)"
   )
   fun unlinkOffences(
     @RequestBody schedulePartIdAndOffenceIds: List<SchedulePartIdAndOffenceId>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/OffenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/OffenceService.kt
@@ -27,7 +27,10 @@ class OffenceService(
 ) {
   fun findOffencesByCode(code: String): List<Offence> {
     log.info("Fetching offences by offenceCode")
-    val offences = offenceRepository.findByCodeStartsWithIgnoreCase(code).map { transform(it) }
+    val offences = offenceRepository.findByCodeStartsWithIgnoreCase(code).map { it ->
+      val children = offenceRepository.findByParentOffenceId(it.id)
+      transform(it, children.map { child -> child.id })
+    }
     return offences.map {
       it.copy(schedules = transform(offenceSchedulePartRepository.findByOffenceId(it.id)))
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/TransformFunctions.kt
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.manageoffencesapi.model.external.sdrs.Offenc
 /*
 ** Functions which transform JPA entity objects into their API model equivalents and vice-versa.
 */
-fun transform(offence: Offence): ModelOffence =
+fun transform(offence: Offence, childOffenceIds: List<Long>? = emptyList()): ModelOffence =
   ModelOffence(
     id = offence.id,
     code = offence.code,
@@ -28,7 +28,10 @@ fun transform(offence: Offence): ModelOffence =
     endDate = offence.endDate,
     homeOfficeStatsCode = offence.homeOfficeStatsCode,
     changedDate = offence.changedDate,
-    loadDate = offence.lastUpdatedDate
+    loadDate = offence.lastUpdatedDate,
+    isChild = offence.parentCode != null,
+    parentOffenceId = offence.parentOffenceId,
+    childOffenceIds = childOffenceIds,
   )
 
 fun transform(offenceScheduleParts: List<OffenceSchedulePart>?): List<ScheduleDetails>? =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/OffencesControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/OffencesControllerIntTest.kt
@@ -169,4 +169,81 @@ class OffencesControllerIntTest : IntegrationTestBase() {
         )
       )
   }
+
+  @Test
+  @Sql(
+    "classpath:test_data/reset-all-data.sql",
+    "classpath:test_data/insert-offence-data-with-children.sql",
+  )
+  fun `Get offences by offence code where offence has associated children`() {
+    val result = webTestClient.get().uri("/offences/code/AF")
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus().isOk
+      .expectBodyList(ModelOffence::class.java)
+      .returnResult().responseBody
+
+    val parentOffenceId = result!!.first { it.code == "AF06999" }.id
+    val childOffenceIds = result.filter { it.code != "AF06999" }.map { it.id }
+
+    assertThat(result)
+      .usingRecursiveComparison()
+      .ignoringFieldsMatchingRegexes(".*dDate")
+      .ignoringFieldsMatchingRegexes("id")
+      .isEqualTo(
+        listOf(
+          ModelOffence(
+            id = 1,
+            code = "AF06999",
+            description = "Brought before the court as being absent without leave from the Armed Forces",
+            cjsTitle = "Brought before the court as being absent without leave from the Armed Forces",
+            revisionId = 570173,
+            startDate = LocalDate.of(2009, 11, 2),
+            endDate = null,
+            changedDate = LocalDateTime.of(2020, 6, 17, 16, 31, 26),
+            loadDate = LocalDateTime.of(2022, 4, 7, 17, 5, 58, 178000000),
+            childOffenceIds = childOffenceIds,
+          ),
+          ModelOffence(
+            id = 2,
+            code = "AF06999A",
+            description = "Inchoate A",
+            cjsTitle = "Inchoate A",
+            revisionId = 570173,
+            startDate = LocalDate.of(2009, 11, 2),
+            endDate = null,
+            changedDate = LocalDateTime.of(2020, 6, 17, 16, 31, 26),
+            loadDate = LocalDateTime.of(2022, 4, 7, 17, 5, 58, 178000000),
+            parentOffenceId = parentOffenceId,
+            isChild = true,
+          ),
+          ModelOffence(
+            id = 3,
+            code = "AF06999B",
+            description = "Inchoate B",
+            cjsTitle = "Inchoate B",
+            revisionId = 570173,
+            startDate = LocalDate.of(2009, 11, 2),
+            endDate = null,
+            changedDate = LocalDateTime.of(2020, 6, 17, 16, 31, 26),
+            loadDate = LocalDateTime.of(2022, 4, 7, 17, 5, 58, 178000000),
+            parentOffenceId = parentOffenceId,
+            isChild = true,
+          ),
+          ModelOffence(
+            id = 4,
+            code = "AF06999C",
+            description = "Inchoate C",
+            cjsTitle = "Inchoate C",
+            revisionId = 570173,
+            startDate = LocalDate.of(2009, 11, 2),
+            endDate = null,
+            changedDate = LocalDateTime.of(2020, 6, 17, 16, 31, 26),
+            loadDate = LocalDateTime.of(2022, 4, 7, 17, 5, 58, 178000000),
+            parentOffenceId = parentOffenceId,
+            isChild = true,
+          ),
+        )
+      )
+  }
 }

--- a/src/test/resources/test_data/insert-offence-data-with-children.sql
+++ b/src/test/resources/test_data/insert-offence-data-with-children.sql
@@ -1,0 +1,14 @@
+INSERT INTO public.offence
+(code, description, revision_id, cjs_title, start_date, end_date, changed_date, created_date, last_updated_date, acts_and_sections)
+VALUES('AF06999', 'Brought before the court as being absent without leave from the Armed Forces', 570173, 'Brought before the court as being absent without leave from the Armed Forces', '2009-11-02', NULL, '2020-01-16 15:19:02.000', '2022-04-07 16:05:58.178', '2022-04-07 16:05:58.178', 'Contrary to section 19 of the Zoo Licensing Act 1981');
+INSERT INTO public.offence
+(code, description, revision_id, cjs_title, start_date, end_date, changed_date, created_date, last_updated_date, acts_and_sections)
+VALUES('AF06999A', 'Inchoate A', 570173, 'Inchoate A', '2009-11-02', NULL, '2020-01-16 15:19:02.000', '2022-04-07 16:05:58.178', '2022-04-07 16:05:58.178', 'Contrary to section 19 of the Zoo Licensing Act 1981');
+INSERT INTO public.offence
+(code, description, revision_id, cjs_title, start_date, end_date, changed_date, created_date, last_updated_date, acts_and_sections)
+VALUES('AF06999B', 'Inchoate B', 570173, 'Inchoate B', '2009-11-02', NULL, '2020-01-16 15:19:02.000', '2022-04-07 16:05:58.178', '2022-04-07 16:05:58.178', 'Contrary to section 19 of the Zoo Licensing Act 1981');
+INSERT INTO public.offence
+(code, description, revision_id, cjs_title, start_date, end_date, changed_date, created_date, last_updated_date, acts_and_sections)
+VALUES('AF06999C', 'Inchoate C', 570173, 'Inchoate C', '2009-11-02', NULL, '2020-01-16 15:19:02.000', '2022-04-07 16:05:58.178', '2022-04-07 16:05:58.178', 'Contrary to section 19 of the Zoo Licensing Act 1981');
+
+UPDATE offence a SET a.parent_offence_id = (SELECT id FROM offence b where b.code = 'AF06999') WHERE code IN ('AF06999A', 'AF06999B', 'AF06999C');


### PR DESCRIPTION
TODO
UI changes to cover the parent/child relationship. Needs some thought due to data anomolies (i.e. some children don't have parents)