### PR TITLE
CRS-2656: New API to support progression model

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/OffenceSdsExclusion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/OffenceSdsExclusion.kt
@@ -51,4 +51,5 @@ enum class OffenceSdsExclusionIndicator {
   NATIONAL_SECURITY,
   TERRORISM,
   MURDER_T3,
+  SCHEDULE_13_PART_3,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/SdsOffenceDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/SdsOffenceDetails.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Shows which (if any) PCSC Marker the offence relates to as well as any SDS early release exclusions for the offence")
+data class SdsOffenceDetails(
+  val offenceCode: String,
+  val pcscMarkers: PcscMarkers,
+  val earlyReleaseExclusions: List<OffenceSdsExclusionIndicator>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleController.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.manageoffencesapi.model.PcscLists
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.Schedule
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.SchedulePartIdAndOffenceId
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.SdsExclusionLists
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.SdsOffenceDetails
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.ToreraSchedulePartCodes
 import uk.gov.justice.digital.hmpps.manageoffencesapi.service.IsOffenceInScheduleService
 import uk.gov.justice.digital.hmpps.manageoffencesapi.service.ScheduleService
@@ -134,6 +135,19 @@ class ScheduleController(
   ): List<OffenceSdsExclusion> {
     log.info("Request received to determine sexual or violent status for ${offenceCodes.size} offence codes")
     return isOffenceInScheduleService.categoriseSdsExclusionsOffences(offenceCodes)
+  }
+
+  @GetMapping(value = ["/sds-offence-details"])
+  @ResponseBody
+  @Operation(
+    summary = "Determine both if the passed in offence codes are related to the PCSC list and whether they have any exclusions to be considered for SDS40 and Progression Model",
+    description = "This endpoint will return a list of offences with PCSC markers and any SDS early release exclusions if applicable.",
+  )
+  fun getSdsOffenceDetails(
+    @RequestParam offenceCodes: List<String>,
+  ): List<SdsOffenceDetails> {
+    log.info("Request received to determine PCSC markers and early release exclusions for ${offenceCodes.size} offence codes")
+    return isOffenceInScheduleService.getSdsOffenceDetails(offenceCodes)
   }
 
   @Cacheable(SDS_EARLY_RELEASE_EXCLUSION_LISTS)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/CachedScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/CachedScheduleService.kt
@@ -23,6 +23,7 @@ class CachedScheduleService(
     val tranceThreeMurderMappings = scheduleService.getTrancheThreeMurderScheduleMappings()
 
     val (part1LifeMappings, part2LifeMappings, seriousViolentOffenceMappings) = scheduleService.getSchedule15PcscMappings()
+    val schedule13Part3Mappings = scheduleService.getSchedule13Part3Mappings()
 
     return CachedScheduleInformation(
       part1Mappings.map { it.offence.code }.toSet(),
@@ -38,6 +39,7 @@ class CachedScheduleService(
       part1LifeMappings.map { OffenceAndStartDate(it.offence.code, it.offence.startDate) }.toSet(),
       part2LifeMappings.map { OffenceAndStartDate(it.offence.code, it.offence.startDate) }.toSet(),
       seriousViolentOffenceMappings.map { OffenceAndStartDate(it.offence.code, it.offence.startDate) }.toSet(),
+      schedule13Part3Mappings.map { it.offence.code }.toSet(),
     )
   }
 }
@@ -56,6 +58,7 @@ data class CachedScheduleInformation(
   val part1LifeMappings: Set<OffenceAndStartDate>,
   val part2LifeMappings: Set<OffenceAndStartDate>,
   val seriousViolentOffenceMappings: Set<OffenceAndStartDate>,
+  val schedule13Part3Mappings: Set<String>,
 )
 
 data class OffenceAndStartDate(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/IsOffenceInScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/IsOffenceInScheduleService.kt
@@ -7,8 +7,10 @@ import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.Feature.T3_OFFENCE_EX
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffencePcscMarkers
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusion
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusion.Companion.getSdsExclusionIndicator
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusionIndicator
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.PcscMarkers
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.ScheduleInfo
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.SdsOffenceDetails
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.FeatureToggleRepository
 import java.time.LocalDate
 
@@ -22,6 +24,7 @@ class IsOffenceInScheduleService(
     log.info("Determining PCSC schedules for passed in offences")
     return getOffencePcscMarkers(offenceCodes)
   }
+
   fun categoriseSdsExclusionsOffences(offenceCodes: List<String>): List<OffenceSdsExclusion> {
     log.info("Determining Sexual or Violent status for passed in offences")
     return getSdsExclusionIndicators(offenceCodes)
@@ -29,41 +32,72 @@ class IsOffenceInScheduleService(
 
   private fun getSdsExclusionIndicators(offenceCodes: List<String>): List<OffenceSdsExclusion> {
     val scheduleInfo = cachedScheduleService.getCachedScheduleInformation()
-    val includeTrancheThree = trancheThreeEnabled()
 
     return offenceCodes.map { offenceCode ->
-      val isSexual = scheduleInfo.part2Mappings.contains(offenceCode) ||
-        hasSexualCodePrefix(offenceCode) ||
-        scheduleInfo.sexualOffencesFromLegislation.contains(offenceCode) ||
-        scheduleInfo.sexScheduleMappings.contains(offenceCode)
+      getSds40Exclusions(offenceCode, scheduleInfo)
+    }
+  }
 
-      val isSexualTranche3 =
-        includeTrancheThree && scheduleInfo.trancheThreeSexScheduleMappings.contains(offenceCode)
-      val isDomesticViolenceTranche3 =
-        includeTrancheThree && scheduleInfo.trancheThreeViolenceMappings.contains(offenceCode)
-      val isMurderTranche3 = includeTrancheThree && scheduleInfo.tranceThreeMurderMappings.contains(offenceCode)
-
-      val isDomesticViolence = scheduleInfo.domesticViolenceMappings.contains(offenceCode)
-      val isNationalSecurity = scheduleInfo.securityOffencesFromLegislation.contains(offenceCode)
-      val isViolent = scheduleInfo.part1Mappings.contains(offenceCode)
-      val isTerrorism = scheduleInfo.terrorismMapping.contains(offenceCode)
-
-      val indicator = getSdsExclusionIndicator(
-        isSexual,
-        isDomesticViolence,
-        isNationalSecurity,
-        isTerrorism,
-        isViolent,
-        isDomesticViolenceTranche3,
-        isSexualTranche3,
-        isMurderTranche3,
-      )
-
-      OffenceSdsExclusion(
+  fun getSdsOffenceDetails(offenceCodes: List<String>): List<SdsOffenceDetails> {
+    log.info("Determining SDS markers for passed in offences")
+    val scheduleInfo = cachedScheduleService.getCachedScheduleInformation()
+    return offenceCodes.map { offenceCode ->
+      val pcscMarkers = getPcscMarkers(offenceCode, scheduleInfo).pcscMarkers
+      val sds40Exclusion = getSds40Exclusions(offenceCode, scheduleInfo).schedulePart.let { sds40ExclusionMarker ->
+        if (sds40ExclusionMarker != OffenceSdsExclusionIndicator.NONE) {
+          sds40ExclusionMarker
+        } else {
+          null
+        }
+      }
+      val progressionModelExclusion = getProgressionModelExclusion(offenceCode, scheduleInfo)
+      SdsOffenceDetails(
         offenceCode = offenceCode,
-        schedulePart = indicator,
+        pcscMarkers = pcscMarkers,
+        earlyReleaseExclusions = listOfNotNull(sds40Exclusion, progressionModelExclusion),
       )
     }
+  }
+
+  private fun getSds40Exclusions(
+    offenceCode: String,
+    scheduleInfo: CachedScheduleInformation,
+  ): OffenceSdsExclusion {
+    val isSexual = scheduleInfo.part2Mappings.contains(offenceCode) ||
+      hasSexualCodePrefix(offenceCode) ||
+      scheduleInfo.sexualOffencesFromLegislation.contains(offenceCode) ||
+      scheduleInfo.sexScheduleMappings.contains(offenceCode)
+
+    val isSexualTranche3 = scheduleInfo.trancheThreeSexScheduleMappings.contains(offenceCode)
+    val isDomesticViolenceTranche3 = scheduleInfo.trancheThreeViolenceMappings.contains(offenceCode)
+    val isMurderTranche3 = scheduleInfo.tranceThreeMurderMappings.contains(offenceCode)
+
+    val isDomesticViolence = scheduleInfo.domesticViolenceMappings.contains(offenceCode)
+    val isNationalSecurity = scheduleInfo.securityOffencesFromLegislation.contains(offenceCode)
+    val isViolent = scheduleInfo.part1Mappings.contains(offenceCode)
+    val isTerrorism = scheduleInfo.terrorismMapping.contains(offenceCode)
+
+    val indicator = getSdsExclusionIndicator(
+      isSexual,
+      isDomesticViolence,
+      isNationalSecurity,
+      isTerrorism,
+      isViolent,
+      isDomesticViolenceTranche3,
+      isSexualTranche3,
+      isMurderTranche3,
+    )
+
+    return OffenceSdsExclusion(
+      offenceCode = offenceCode,
+      schedulePart = indicator,
+    )
+  }
+
+  private fun getProgressionModelExclusion(offenceCode: String, scheduleInfo: CachedScheduleInformation): OffenceSdsExclusionIndicator? = if (scheduleInfo.schedule13Part3Mappings.contains(offenceCode)) {
+    OffenceSdsExclusionIndicator.SCHEDULE_13_PART_3
+  } else {
+    null
   }
 
   private fun hasSexualCodePrefix(offenceCode: String): Boolean = SEXUAL_CODES_FOR_EXCLUSION_LIST.any { offenceCode.startsWith(it) }
@@ -72,17 +106,22 @@ class IsOffenceInScheduleService(
     val scheduleInfo = cachedScheduleService.getCachedScheduleInformation()
 
     return offenceCodes.map {
-      OffencePcscMarkers(
-        offenceCode = it,
-        PcscMarkers(
-          inListA = inListA(scheduleInfo.part1LifeMappings, scheduleInfo.part2LifeMappings, it),
-          inListB = inListB(scheduleInfo.seriousViolentOffenceMappings, scheduleInfo.part2LifeMappings, it),
-          inListC = inListC(scheduleInfo.seriousViolentOffenceMappings, scheduleInfo.part2LifeMappings, it),
-          inListD = inListD(scheduleInfo.part1LifeMappings, scheduleInfo.part2LifeMappings, it),
-        ),
-      )
+      getPcscMarkers(it, scheduleInfo)
     }
   }
+
+  private fun getPcscMarkers(
+    offenceCode: String,
+    scheduleInfo: CachedScheduleInformation,
+  ): OffencePcscMarkers = OffencePcscMarkers(
+    offenceCode = offenceCode,
+    PcscMarkers(
+      inListA = inListA(scheduleInfo.part1LifeMappings, scheduleInfo.part2LifeMappings, offenceCode),
+      inListB = inListB(scheduleInfo.seriousViolentOffenceMappings, scheduleInfo.part2LifeMappings, offenceCode),
+      inListC = inListC(scheduleInfo.seriousViolentOffenceMappings, scheduleInfo.part2LifeMappings, offenceCode),
+      inListD = inListD(scheduleInfo.part1LifeMappings, scheduleInfo.part2LifeMappings, offenceCode),
+    ),
+  )
 
   // List A: Schedule 15 Part 1 + Schedule 15 Part 2 that attract life (exclude all offences that start on or after 28 June 2022)
 // NOMIS SCHEDULE_15_ATTRACTS_LIFE - SDS >7 years between 01 April 2020 and 28 June 2022

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/ScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/ScheduleService.kt
@@ -442,6 +442,14 @@ class ScheduleService(
     return Pair(part1Mappings, part2Mappings)
   }
 
+  fun getSchedule13Part3Mappings(): List<OffenceScheduleMapping> {
+    val mappings = offenceScheduleMappingRepository.findBySchedulePartScheduleActAndSchedulePartScheduleCode(
+      SCHEDULE_13.act,
+      SCHEDULE_13.code,
+    )
+    return mappings.filter { it.schedulePart.partNumber == 3 }
+  }
+
   fun getDomesticViolenceScheduleMappings(): Pair<List<OffenceScheduleMapping>, List<OffenceScheduleMapping>> {
     val mappings = offenceScheduleMappingRepository.findBySchedulePartScheduleActAndSchedulePartScheduleCode(
       DOMESTIC_VIOLENCE_SCHEDULE.act,
@@ -555,6 +563,10 @@ class ScheduleService(
     val TERRORISM_SCHEDULE = ScheduleInfo(
       act = "Terrorism Excluded Offences",
       code = "TEO",
+    )
+    val SCHEDULE_13 = ScheduleInfo(
+      act = "Sentencing Act 2020",
+      code = "13",
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleControllerIntTest.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusion
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusionIndicator.DOMESTIC_ABUSE
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusionIndicator.NATIONAL_SECURITY
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusionIndicator.NONE
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusionIndicator.SCHEDULE_13_PART_3
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusionIndicator.SEXUAL
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusionIndicator.TERRORISM
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusionIndicator.VIOLENT
@@ -21,6 +22,7 @@ import uk.gov.justice.digital.hmpps.manageoffencesapi.model.Schedule
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.SchedulePart
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.SchedulePartIdAndOffenceId
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.SdsExclusionLists
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.SdsOffenceDetails
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -133,6 +135,43 @@ class ScheduleControllerIntTest : IntegrationTestBase() {
           OffenceSdsExclusion(offenceCode = "DV00001", schedulePart = DOMESTIC_ABUSE),
           OffenceSdsExclusion(offenceCode = "NSLEGIS", schedulePart = NATIONAL_SECURITY),
           OffenceSdsExclusion(offenceCode = "TR00001", schedulePart = TERRORISM),
+        ),
+      )
+  }
+
+  @Test
+  @Sql(
+    "classpath:test_data/reset-all-data.sql",
+    "classpath:test_data/insert-offence-data-sds-exclusions.sql",
+    "classpath:test_data/set-progression-model-offence-data-sds-exclusions.sql",
+  )
+  fun `Get PCSC markers and early release exclusion indicators for multiple offences by offence codes`() {
+    resetCache()
+    val result = webTestClient.get()
+      .uri("/schedule/sds-offence-details?offenceCodes=AB14001,AB14002,AB14003,AF06999,SX03TEST,SX56TEST,SXLEGIS,DV00001,NSLEGIS,TR00001")
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus().isOk
+      .expectBodyList(SdsOffenceDetails::class.java)
+      .returnResult().responseBody
+
+    val noPcscMarkers = PcscMarkers(inListA = false, inListB = false, inListC = false, inListD = false)
+    val allPcscMarkers = PcscMarkers(inListA = true, inListB = true, inListC = true, inListD = true)
+    assertThat(result)
+      .usingRecursiveComparison()
+      .ignoringCollectionOrder()
+      .isEqualTo(
+        listOf(
+          SdsOffenceDetails(offenceCode = "AB14001", pcscMarkers = noPcscMarkers, earlyReleaseExclusions = listOf(VIOLENT)),
+          SdsOffenceDetails(offenceCode = "AB14002", pcscMarkers = allPcscMarkers, earlyReleaseExclusions = listOf(SEXUAL)),
+          SdsOffenceDetails(offenceCode = "SX03TEST", pcscMarkers = noPcscMarkers, earlyReleaseExclusions = listOf(SEXUAL)),
+          SdsOffenceDetails(offenceCode = "SX56TEST", pcscMarkers = noPcscMarkers, earlyReleaseExclusions = listOf(SEXUAL)),
+          SdsOffenceDetails(offenceCode = "AB14003", pcscMarkers = noPcscMarkers, earlyReleaseExclusions = listOf()),
+          SdsOffenceDetails(offenceCode = "AF06999", pcscMarkers = noPcscMarkers, earlyReleaseExclusions = listOf()),
+          SdsOffenceDetails(offenceCode = "SXLEGIS", pcscMarkers = noPcscMarkers, earlyReleaseExclusions = listOf(SEXUAL)),
+          SdsOffenceDetails(offenceCode = "DV00001", pcscMarkers = noPcscMarkers, earlyReleaseExclusions = listOf(DOMESTIC_ABUSE)),
+          SdsOffenceDetails(offenceCode = "NSLEGIS", pcscMarkers = noPcscMarkers, earlyReleaseExclusions = listOf(NATIONAL_SECURITY, SCHEDULE_13_PART_3)),
+          SdsOffenceDetails(offenceCode = "TR00001", pcscMarkers = noPcscMarkers, earlyReleaseExclusions = listOf(TERRORISM)),
         ),
       )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/IsOffenceInScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/IsOffenceInScheduleServiceTest.kt
@@ -12,7 +12,9 @@ import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.Schedule
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.SchedulePart
 import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.SdrsCache
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffencePcscMarkers
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusionIndicator
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.PcscMarkers
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.SdsOffenceDetails
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.FeatureToggleRepository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.NomisScheduleMappingRepository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceRepository
@@ -20,6 +22,9 @@ import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceSchedule
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.OffenceToSyncWithNomisRepository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.SchedulePartRepository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.ScheduleRepository
+import uk.gov.justice.digital.hmpps.manageoffencesapi.service.ScheduleService.Companion.NATIONAL_SECURITY_LEGISLATION
+import uk.gov.justice.digital.hmpps.manageoffencesapi.service.ScheduleService.Companion.SCHEDULE_13
+import uk.gov.justice.digital.hmpps.manageoffencesapi.service.ScheduleService.Companion.SEXUAL_OFFENCES_LEGISLATION
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -59,7 +64,7 @@ class IsOffenceInScheduleServiceTest {
   inner class PcscTests {
     @Test
     fun `Determine PCSC offences when all indicators are false`() {
-      whenever(schedulePartRepository.findByScheduleId(SCHEDULE_15.id)).thenReturn(
+      whenever(schedulePartRepository.findByScheduleId(SCHEDULE_15_ENTITY.id)).thenReturn(
         listOf(
           SCHEDULE_15_PART_1,
           SCHEDULE_15_PART_2,
@@ -93,7 +98,7 @@ class IsOffenceInScheduleServiceTest {
 
     @Test
     fun `Determine PCSC offences when all indicators are true`() {
-      whenever(schedulePartRepository.findByScheduleId(SCHEDULE_15.id)).thenReturn(
+      whenever(schedulePartRepository.findByScheduleId(SCHEDULE_15_ENTITY.id)).thenReturn(
         listOf(
           SCHEDULE_15_PART_1,
           SCHEDULE_15_PART_2,
@@ -130,7 +135,7 @@ class IsOffenceInScheduleServiceTest {
 
     @Test
     fun `Determine PCSC offences with a mix of indicators true and false`() {
-      whenever(schedulePartRepository.findByScheduleId(SCHEDULE_15.id)).thenReturn(
+      whenever(schedulePartRepository.findByScheduleId(SCHEDULE_15_ENTITY.id)).thenReturn(
         listOf(
           SCHEDULE_15_PART_1,
           SCHEDULE_15_PART_2,
@@ -165,12 +170,124 @@ class IsOffenceInScheduleServiceTest {
     }
   }
 
+  @Nested
+  inner class CombinedSDSMarkersTests {
+    @Test
+    fun `Can fetch SDS markers for offence with PCSC markers and include SDS 40 exclusion`() {
+      whenever(schedulePartRepository.findByScheduleId(SCHEDULE_15_ENTITY.id)).thenReturn(
+        listOf(
+          SCHEDULE_15_PART_1,
+          SCHEDULE_15_PART_2,
+        ),
+      )
+      whenever(
+        offenceScheduleMappingRepository.findBySchedulePartScheduleActAndSchedulePartScheduleCode(
+          "Criminal Justice Act 2003",
+          "15",
+        ),
+      ).thenReturn(
+        listOf(
+          OFFENCE_SCHEDULE_MAPPING_S15_P1_LIFE_AFTER_CUTOFF,
+        ),
+      )
+      val res = isOffenceInScheduleService.getSdsOffenceDetails(listOf(BASE_OFFENCE.code))
+      assertThat(res).isEqualTo(
+        listOf(
+          SdsOffenceDetails(
+            offenceCode = BASE_OFFENCE.code,
+            PcscMarkers(
+              inListA = false,
+              inListB = true,
+              inListC = true,
+              inListD = true,
+            ),
+            listOf(OffenceSdsExclusionIndicator.VIOLENT),
+          ),
+        ),
+      )
+    }
+
+    @Test
+    fun `Can fetch SDS markers for offence with no PCSC markers but with an SDS 40 exclusions`() {
+      whenever(schedulePartRepository.findByScheduleId(SCHEDULE_15_ENTITY.id)).thenReturn(
+        listOf(
+          SCHEDULE_15_PART_1,
+          SCHEDULE_15_PART_2,
+        ),
+      )
+      whenever(
+        offenceScheduleMappingRepository.findBySchedulePartScheduleActAndSchedulePartScheduleCode(
+          "Criminal Justice Act 2003",
+          "15",
+        ),
+      ).thenReturn(emptyList())
+      whenever(offenceRepository.findByLegislationLikeIgnoreCase(SEXUAL_OFFENCES_LEGISLATION))
+        .thenReturn(listOf(BASE_OFFENCE))
+
+      val res = isOffenceInScheduleService.getSdsOffenceDetails(listOf(BASE_OFFENCE.code))
+      assertThat(res).isEqualTo(
+        listOf(
+          SdsOffenceDetails(
+            offenceCode = BASE_OFFENCE.code,
+            PcscMarkers(
+              inListA = false,
+              inListB = false,
+              inListC = false,
+              inListD = false,
+            ),
+            listOf(OffenceSdsExclusionIndicator.SEXUAL),
+          ),
+        ),
+      )
+    }
+
+    @Test
+    fun `Can fetch SDS markers for offence without PCSC markers but with both a SDS40 and progression model exclusion`() {
+      whenever(
+        offenceRepository.findByLegislationLikeIgnoreCase(
+          NATIONAL_SECURITY_LEGISLATION[0],
+          NATIONAL_SECURITY_LEGISLATION[1],
+          NATIONAL_SECURITY_LEGISLATION[2],
+          NATIONAL_SECURITY_LEGISLATION[3],
+        ),
+      )
+        .thenReturn(listOf(BASE_OFFENCE))
+
+      whenever(
+        offenceScheduleMappingRepository.findBySchedulePartScheduleActAndSchedulePartScheduleCode(
+          SCHEDULE_13.act,
+          SCHEDULE_13.code,
+        ),
+      ).thenReturn(listOf(OFFENCE_SCHEDULE_MAPPING_S13_P3))
+
+      val res = isOffenceInScheduleService.getSdsOffenceDetails(listOf(BASE_OFFENCE.code))
+      assertThat(res).isEqualTo(
+        listOf(
+          SdsOffenceDetails(
+            offenceCode = BASE_OFFENCE.code,
+            PcscMarkers(
+              inListA = false,
+              inListB = false,
+              inListC = false,
+              inListD = false,
+            ),
+            listOf(OffenceSdsExclusionIndicator.NATIONAL_SECURITY, OffenceSdsExclusionIndicator.SCHEDULE_13_PART_3),
+          ),
+        ),
+      )
+    }
+  }
+
   companion object {
     private const val SCHEDULE_PART_ID_92 = 92L
     private const val SCHEDULE_PART_ID_93 = 93L
-    private val SCHEDULE_15 = Schedule(code = "15", id = 15, act = "Act", url = "url")
-    private val SCHEDULE_15_PART_1 = SchedulePart(id = SCHEDULE_PART_ID_92, partNumber = 1, schedule = SCHEDULE_15)
-    private val SCHEDULE_15_PART_2 = SchedulePart(id = SCHEDULE_PART_ID_93, partNumber = 2, schedule = SCHEDULE_15)
+    private val SCHEDULE_15_ENTITY = Schedule(code = "15", id = 15, act = "Act", url = "url")
+    private val SCHEDULE_15_PART_1 = SchedulePart(id = SCHEDULE_PART_ID_92, partNumber = 1, schedule = SCHEDULE_15_ENTITY)
+    private val SCHEDULE_15_PART_2 = SchedulePart(id = SCHEDULE_PART_ID_93, partNumber = 2, schedule = SCHEDULE_15_ENTITY)
+
+    private const val SCHEDULE_PART_ID_99 = 99L
+    private val SCHEDULE_13_ENTITY = Schedule(code = "13", id = 13, act = "Act", url = "url")
+    private val SCHEDULE_13_PART_3 = SchedulePart(id = SCHEDULE_PART_ID_99, partNumber = 3, schedule = SCHEDULE_13_ENTITY)
 
     private val BASE_OFFENCE = Offence(
       code = "AABB011",
@@ -179,7 +296,7 @@ class IsOffenceInScheduleServiceTest {
       startDate = LocalDate.now(),
       sdrsCache = SdrsCache.OFFENCES_A,
     )
-    val BEFORE_SDS_LIST_A_CUT_OFF_DATE = LocalDate.of(2022, 6, 27)
+    private val BEFORE_SDS_LIST_A_CUT_OFF_DATE = LocalDate.of(2022, 6, 27)
     private val OFFENCE_SCHEDULE_MAPPING_S15_P1_LIFE = OffenceScheduleMapping(
       offence = BASE_OFFENCE.copy(maxPeriodIsLife = true, startDate = BEFORE_SDS_LIST_A_CUT_OFF_DATE),
       schedulePart = SCHEDULE_15_PART_1,
@@ -189,6 +306,10 @@ class IsOffenceInScheduleServiceTest {
       offence = BASE_OFFENCE.copy(maxPeriodIsLife = true),
       schedulePart = SCHEDULE_15_PART_1,
       paragraphNumber = "65",
+    )
+    private val OFFENCE_SCHEDULE_MAPPING_S13_P3 = OffenceScheduleMapping(
+      offence = BASE_OFFENCE,
+      schedulePart = SCHEDULE_13_PART_3,
     )
   }
 }

--- a/src/test/resources/test_data/reset-all-data.sql
+++ b/src/test/resources/test_data/reset-all-data.sql
@@ -12,3 +12,4 @@ UPDATE sdrs_load_result SET status = NULL, load_type = NULL, load_date = NULL, l
 UPDATE feature_toggle SET enabled = TRUE;
 UPDATE feature_toggle SET enabled = FALSE WHERE feature = 'FULL_SYNC_SDRS';
 
+DELETE from schedule_part WHERE schedule_id = (select id from schedule where code = '13') AND part_number = 3;

--- a/src/test/resources/test_data/set-progression-model-offence-data-sds-exclusions.sql
+++ b/src/test/resources/test_data/set-progression-model-offence-data-sds-exclusions.sql
@@ -1,0 +1,3 @@
+INSERT INTO schedule_part (schedule_id, part_number) (SELECT id, 3 FROM schedule WHERE code = '13');
+INSERT INTO offence_schedule_mapping (offence_id, schedule_part_id) values ((select id from offence o where o.code = 'NSLEGIS'), (select id from schedule_part where schedule_id = (select id from schedule where code = '13') AND part_number = 3));
+UPDATE offence SET max_period_is_life = true WHERE code = 'AB14002';


### PR DESCRIPTION
This is a combined version for getting PCSC markers and SDS early release exclusions for all offences in a single call. It also adds a new exclusion check for Schedule 13 Part 3 which are excluded for progression model.

It can return an SDS40 exclusion and a separate exclusion for progression model which both are relevant as if you are excluded from progression model then you might still be eligible for SDS40.

An empty list represents no exclusion which is slightly different to the old API which returned NONE