### PR TITLE
CRS-2656: Export OffenceSdsExclusionIndicator as an enum in OpenAPI

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/OffenceSdsExclusion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/OffenceSdsExclusion.kt
@@ -40,7 +40,7 @@ data class OffenceSdsExclusion(
   }
 }
 
-@Schema(description = "Categories for the offence")
+@Schema(description = "Categories for the offence", enumAsRef = true)
 enum class OffenceSdsExclusionIndicator {
   SEXUAL,
   SEXUAL_T3,


### PR DESCRIPTION
This is so the same type is generated across both APIs using the enum.