### PR TITLE
CRS-2813: New exclusion for progression model

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/OffenceSdsExclusion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/OffenceSdsExclusion.kt
@@ -52,4 +52,5 @@ enum class OffenceSdsExclusionIndicator {
   TERRORISM,
   MURDER_T3,
   SCHEDULE_13_PART_3,
+  SENTENCING_ACT_2026_PROGRESSION_MODEL,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/CachedScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/CachedScheduleService.kt
@@ -24,6 +24,7 @@ class CachedScheduleService(
 
     val (part1LifeMappings, part2LifeMappings, seriousViolentOffenceMappings) = scheduleService.getSchedule15PcscMappings()
     val schedule13Part3Mappings = scheduleService.getSchedule13Part3Mappings()
+    val sentencingAct2026ProgressionModelMappings = scheduleService.getSentencingAct2026ProgressionModelMappings()
 
     return CachedScheduleInformation(
       part1Mappings.map { it.offence.code }.toSet(),
@@ -40,6 +41,7 @@ class CachedScheduleService(
       part2LifeMappings.map { OffenceAndStartDate(it.offence.code, it.offence.startDate) }.toSet(),
       seriousViolentOffenceMappings.map { OffenceAndStartDate(it.offence.code, it.offence.startDate) }.toSet(),
       schedule13Part3Mappings.map { it.offence.code }.toSet(),
+      sentencingAct2026ProgressionModelMappings.map { it.offence.code }.toSet(),
     )
   }
 }
@@ -59,6 +61,7 @@ data class CachedScheduleInformation(
   val part2LifeMappings: Set<OffenceAndStartDate>,
   val seriousViolentOffenceMappings: Set<OffenceAndStartDate>,
   val schedule13Part3Mappings: Set<String>,
+  val sentencingAct2026ProgressionModelExclusions: Set<String>,
 )
 
 data class OffenceAndStartDate(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/IsOffenceInScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/IsOffenceInScheduleService.kt
@@ -50,11 +50,11 @@ class IsOffenceInScheduleService(
           null
         }
       }
-      val progressionModelExclusion = getProgressionModelExclusion(offenceCode, scheduleInfo)
+      val progressionModelExclusions = getProgressionModelExclusions(offenceCode, scheduleInfo)
       SdsOffenceDetails(
         offenceCode = offenceCode,
         pcscMarkers = pcscMarkers,
-        earlyReleaseExclusions = listOfNotNull(sds40Exclusion, progressionModelExclusion),
+        earlyReleaseExclusions = listOfNotNull(sds40Exclusion) + progressionModelExclusions,
       )
     }
   }
@@ -94,11 +94,10 @@ class IsOffenceInScheduleService(
     )
   }
 
-  private fun getProgressionModelExclusion(offenceCode: String, scheduleInfo: CachedScheduleInformation): OffenceSdsExclusionIndicator? = if (scheduleInfo.schedule13Part3Mappings.contains(offenceCode)) {
-    OffenceSdsExclusionIndicator.SCHEDULE_13_PART_3
-  } else {
-    null
-  }
+  private fun getProgressionModelExclusions(offenceCode: String, scheduleInfo: CachedScheduleInformation): List<OffenceSdsExclusionIndicator> = listOfNotNull(
+    if (scheduleInfo.schedule13Part3Mappings.contains(offenceCode)) OffenceSdsExclusionIndicator.SCHEDULE_13_PART_3 else null,
+    if (scheduleInfo.sentencingAct2026ProgressionModelExclusions.contains(offenceCode)) OffenceSdsExclusionIndicator.SENTENCING_ACT_2026_PROGRESSION_MODEL else null,
+  )
 
   private fun hasSexualCodePrefix(offenceCode: String): Boolean = SEXUAL_CODES_FOR_EXCLUSION_LIST.any { offenceCode.startsWith(it) }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/ScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/ScheduleService.kt
@@ -358,6 +358,11 @@ class ScheduleService(
     TRANCHE_THREE_MURDER_SCHEDULE.code,
   )
 
+  fun getSentencingAct2026ProgressionModelMappings() = offenceScheduleMappingRepository.findBySchedulePartScheduleActAndSchedulePartScheduleCode(
+    SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.act,
+    SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.code,
+  )
+
   fun getSdsExclusionLists(): SdsExclusionLists {
     val (part1Mappings, part2Mappings) = getSchedule15Mappings()
     val (domesticViolenceMappings, trancheThreeDomesticViolenceMappings) = getDomesticViolenceScheduleMappings()
@@ -574,6 +579,10 @@ class ScheduleService(
     val SCHEDULE_13 = ScheduleInfo(
       act = "Sentencing Act 2020",
       code = "13",
+    )
+    val SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE = ScheduleInfo(
+      act = "SA2026 Excluded Offences for Progression Model",
+      code = "SA2026 EOPM",
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/IsOffenceInScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/IsOffenceInScheduleServiceTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.SchedulePartRep
 import uk.gov.justice.digital.hmpps.manageoffencesapi.repository.ScheduleRepository
 import uk.gov.justice.digital.hmpps.manageoffencesapi.service.ScheduleService.Companion.NATIONAL_SECURITY_LEGISLATION
 import uk.gov.justice.digital.hmpps.manageoffencesapi.service.ScheduleService.Companion.SCHEDULE_13
+import uk.gov.justice.digital.hmpps.manageoffencesapi.service.ScheduleService.Companion.SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE
 import uk.gov.justice.digital.hmpps.manageoffencesapi.service.ScheduleService.Companion.SEXUAL_OFFENCES_LEGISLATION
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -237,7 +238,7 @@ class IsOffenceInScheduleServiceTest {
     }
 
     @Test
-    fun `Can fetch SDS markers for offence without PCSC markers but with both a SDS40 and progression model exclusion`() {
+    fun `Can fetch SDS markers for offence without PCSC markers but with both a SDS40 and progression model schedule 13 part 3 exclusion`() {
       whenever(
         offenceRepository.findByLegislationLikeIgnoreCase(
           NATIONAL_SECURITY_LEGISLATION[0],
@@ -267,6 +268,42 @@ class IsOffenceInScheduleServiceTest {
               inListD = false,
             ),
             listOf(OffenceSdsExclusionIndicator.NATIONAL_SECURITY, OffenceSdsExclusionIndicator.SCHEDULE_13_PART_3),
+          ),
+        ),
+      )
+    }
+
+    @Test
+    fun `Can fetch SDS markers for offence without PCSC markers but with both a SDS40 and SA2026 progression model exclusion`() {
+      whenever(
+        offenceRepository.findByLegislationLikeIgnoreCase(
+          NATIONAL_SECURITY_LEGISLATION[0],
+          NATIONAL_SECURITY_LEGISLATION[1],
+          NATIONAL_SECURITY_LEGISLATION[2],
+          NATIONAL_SECURITY_LEGISLATION[3],
+        ),
+      )
+        .thenReturn(listOf(BASE_OFFENCE))
+
+      whenever(
+        offenceScheduleMappingRepository.findBySchedulePartScheduleActAndSchedulePartScheduleCode(
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.act,
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.code,
+        ),
+      ).thenReturn(listOf(OFFENCE_SCHEDULE_MAPPING_S13_P3))
+
+      val res = isOffenceInScheduleService.getSdsOffenceDetails(listOf(BASE_OFFENCE.code))
+      assertThat(res).isEqualTo(
+        listOf(
+          SdsOffenceDetails(
+            offenceCode = BASE_OFFENCE.code,
+            PcscMarkers(
+              inListA = false,
+              inListB = false,
+              inListC = false,
+              inListD = false,
+            ),
+            listOf(OffenceSdsExclusionIndicator.NATIONAL_SECURITY, OffenceSdsExclusionIndicator.SENTENCING_ACT_2026_PROGRESSION_MODEL),
           ),
         ),
       )


### PR DESCRIPTION
The new exclusion comes from the SA2026 EOPM schedule being created in manage offences.