### PR TITLE
MOP-240: Add progression model exclusion lists API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/config/CacheConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/config/CacheConfiguration.kt
@@ -26,11 +26,12 @@ class CacheConfiguration {
     SCHEDULE_19ZA_OFFENCES,
     OFFENCE_CODE_TO_HOME_OFFICE_CODE,
     SCHEDULE_DATA,
+    PROGRESSION_MODEL_EXCLUSION_LISTS,
   )
 
   @CacheEvict(
     allEntries = true,
-    cacheNames = [PCSC_LISTS, SDS_EARLY_RELEASE_EXCLUSION_LISTS, TORERA_OFFENCE_CODES, SCHEDULE_DATA],
+    cacheNames = [PCSC_LISTS, SDS_EARLY_RELEASE_EXCLUSION_LISTS, TORERA_OFFENCE_CODES, SCHEDULE_DATA, PROGRESSION_MODEL_EXCLUSION_LISTS],
   )
   @Scheduled(fixedDelay = 2, timeUnit = HOURS)
   fun cacheEvict() {}
@@ -48,6 +49,7 @@ class CacheConfiguration {
     val log: Logger = LoggerFactory.getLogger(CacheConfiguration::class.java)
     const val PCSC_LISTS: String = "pcscLists"
     const val SDS_EARLY_RELEASE_EXCLUSION_LISTS: String = "sdsEarlyReleaseExclusionLists"
+    const val PROGRESSION_MODEL_EXCLUSION_LISTS: String = "progressionModelExclusionLists"
     const val TORERA_OFFENCE_CODES: String = "toreraOffenceCodes"
     const val SCHEDULE_19ZA_OFFENCES: String = "schedule19ZaOffences"
     const val OFFENCE_CODE_TO_HOME_OFFICE_CODE: String = "offenceCodesToHomeOfficeCode"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/ProgressionModelExclusionLists.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/model/ProgressionModelExclusionLists.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.manageoffencesapi.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Contains the list of all the offences that are excluded from progression model")
+data class ProgressionModelExclusionLists(
+  @param:Schema(description = "Offence under the SA2026 Excluded Offences for Progression Model schedule")
+  val sentencingAct2026ProgressionModelExclusions: Set<OffenceToScheduleMapping>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleController.kt
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.manageoffencesapi.config.CacheConfiguration.Companion.PCSC_LISTS
+import uk.gov.justice.digital.hmpps.manageoffencesapi.config.CacheConfiguration.Companion.PROGRESSION_MODEL_EXCLUSION_LISTS
 import uk.gov.justice.digital.hmpps.manageoffencesapi.config.CacheConfiguration.Companion.SCHEDULE_19ZA_OFFENCES
 import uk.gov.justice.digital.hmpps.manageoffencesapi.config.CacheConfiguration.Companion.SDS_EARLY_RELEASE_EXCLUSION_LISTS
 import uk.gov.justice.digital.hmpps.manageoffencesapi.config.CacheConfiguration.Companion.TORERA_OFFENCE_CODES
@@ -27,6 +28,7 @@ import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffencePcscMarkers
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusion
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceToScheduleMapping
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.PcscLists
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.ProgressionModelExclusionLists
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.Schedule
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.SchedulePart
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.SchedulePartIdAndOffenceId
@@ -195,7 +197,7 @@ class ScheduleController(
   @GetMapping(value = ["/sds-early-release-exclusion-lists"])
   @ResponseBody
   @Operation(
-    summary = "Retrieves the lists of all the offences that are to be excluded from early release.",
+    summary = "Retrieves the lists of all the offences that are to be excluded from SDS40 early release.",
     description = "This returns five lists for Sexual, Violent, Domestic Abuse, National Security or Terrorism offences.",
   )
   fun getSdsExclusionLists(): SdsExclusionLists {
@@ -231,6 +233,18 @@ class ScheduleController(
   fun getPcscLists(): PcscLists {
     log.info("Request received to get PCSC Lists")
     return scheduleService.getPcscLists()
+  }
+
+  @Cacheable(PROGRESSION_MODEL_EXCLUSION_LISTS)
+  @GetMapping(value = ["/progression-model-exclusion-lists"])
+  @ResponseBody
+  @Operation(
+    summary = "Retrieves the lists of all the offences that are to be excluded from Progression Model.",
+    description = "This returns five lists for Sexual, Violent, Domestic Abuse, National Security or Terrorism offences.",
+  )
+  fun getProgressionModelExclusionLists(): ProgressionModelExclusionLists {
+    log.info("Request received to get list progression model exclusions")
+    return scheduleService.getProgressionModelExclusionLists()
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/ScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/ScheduleService.kt
@@ -19,6 +19,7 @@ import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffencePcscMarkers
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceToScheduleMapping
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.PcscLists
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.PcscMarkers
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.ProgressionModelExclusionLists
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.ScheduleInfo
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.SchedulePartIdAndOffenceId
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.SdsExclusionLists
@@ -358,10 +359,22 @@ class ScheduleService(
     TRANCHE_THREE_MURDER_SCHEDULE.code,
   )
 
-  fun getSentencingAct2026ProgressionModelMappings() = offenceScheduleMappingRepository.findBySchedulePartScheduleActAndSchedulePartScheduleCode(
-    SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.act,
-    SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.code,
-  )
+  fun getProgressionModelExclusionLists(): ProgressionModelExclusionLists = ProgressionModelExclusionLists(sentencingAct2026ProgressionModelExclusions = getSentencingAct2026ProgressionModelMappings().map { transform(it) }.sortedBy { it.code }.toSet())
+
+  fun getSentencingAct2026ProgressionModelMappings(): List<OffenceScheduleMapping> {
+    val schedule = scheduleRepository.findOneByActAndCode(
+      SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.act,
+      SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.code,
+    )
+    return if (schedule == null || schedule.status != ScheduleStatus.LIVE) {
+      emptyList()
+    } else {
+      offenceScheduleMappingRepository.findBySchedulePartScheduleActAndSchedulePartScheduleCode(
+        SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.act,
+        SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.code,
+      )
+    }
+  }
 
   fun getSdsExclusionLists(): SdsExclusionLists {
     val (part1Mappings, part2Mappings) = getSchedule15Mappings()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/resource/ScheduleControllerIntTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusionI
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusionIndicator.VIOLENT
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceToScheduleMapping
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.PcscMarkers
+import uk.gov.justice.digital.hmpps.manageoffencesapi.model.ProgressionModelExclusionLists
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.Schedule
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.SchedulePart
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.SchedulePartIdAndOffenceId
@@ -290,6 +291,48 @@ class ScheduleControllerIntTest : IntegrationTestBase() {
               changedDate = changeDate,
               startDate = startDate,
               loadDate = loadDate,
+            ),
+          ),
+        ),
+      )
+  }
+
+  @Test
+  @Sql(
+    "classpath:test_data/reset-all-data.sql",
+    "classpath:test_data/insert-progression-model-test-exclusions.sql",
+  )
+  fun `Get progression model exclusion lists`() {
+    val result = webTestClient.get().uri("/schedule/progression-model-exclusion-lists")
+      .headers(setAuthorisation())
+      .exchange()
+      .expectStatus().isOk
+      .expectBody(ProgressionModelExclusionLists::class.java)
+      .returnResult().responseBody
+
+    assertThat(result).usingRecursiveComparison()
+      .ignoringFieldsMatchingRegexes(".*id|.*isChild|.*childOffences|.*changedDate|.*loadDate")
+      .ignoringCollectionOrder()
+      .isEqualTo(
+        ProgressionModelExclusionLists(
+          setOf(
+            OffenceToScheduleMapping(
+              id = 698,
+              description = "Some exclusion CJS",
+              code = "PM01",
+              revisionId = 570173,
+              changedDate = LocalDateTime.now(),
+              startDate = LocalDate.of(2009, 11, 2),
+              loadDate = LocalDateTime.now(),
+            ),
+            OffenceToScheduleMapping(
+              id = 699,
+              description = "Another exclusion CJS",
+              code = "PM02",
+              revisionId = 574415,
+              changedDate = LocalDateTime.now(),
+              startDate = LocalDate.of(2015, 3, 13),
+              loadDate = LocalDateTime.now(),
             ),
           ),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/IsOffenceInScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/manageoffencesapi/service/IsOffenceInScheduleServiceTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.Offence
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.OffenceScheduleMapping
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.Schedule
 import uk.gov.justice.digital.hmpps.manageoffencesapi.entity.SchedulePart
+import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.ScheduleStatus
 import uk.gov.justice.digital.hmpps.manageoffencesapi.enum.SdrsCache
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffencePcscMarkers
 import uk.gov.justice.digital.hmpps.manageoffencesapi.model.OffenceSdsExclusionIndicator
@@ -286,6 +287,20 @@ class IsOffenceInScheduleServiceTest {
         .thenReturn(listOf(BASE_OFFENCE))
 
       whenever(
+        scheduleRepository.findOneByActAndCode(
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.act,
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.code,
+        ),
+      ).thenReturn(
+        Schedule(
+          1000,
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.act,
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.code,
+          "/foo",
+          ScheduleStatus.LIVE,
+        ),
+      )
+      whenever(
         offenceScheduleMappingRepository.findBySchedulePartScheduleActAndSchedulePartScheduleCode(
           SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.act,
           SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.code,
@@ -303,7 +318,84 @@ class IsOffenceInScheduleServiceTest {
               inListC = false,
               inListD = false,
             ),
-            listOf(OffenceSdsExclusionIndicator.NATIONAL_SECURITY, OffenceSdsExclusionIndicator.SENTENCING_ACT_2026_PROGRESSION_MODEL),
+            listOf(
+              OffenceSdsExclusionIndicator.NATIONAL_SECURITY,
+              OffenceSdsExclusionIndicator.SENTENCING_ACT_2026_PROGRESSION_MODEL,
+            ),
+          ),
+        ),
+      )
+    }
+
+    @Test
+    fun `Can fetch SDS markers for offence when SA2026 progression model exclusion schedule does not exist yet`() {
+      whenever(
+        scheduleRepository.findOneByActAndCode(
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.act,
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.code,
+        ),
+      ).thenReturn(null)
+
+      whenever(
+        offenceScheduleMappingRepository.findBySchedulePartScheduleActAndSchedulePartScheduleCode(
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.act,
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.code,
+        ),
+      ).thenReturn(listOf(OFFENCE_SCHEDULE_MAPPING_S13_P3))
+
+      val res = isOffenceInScheduleService.getSdsOffenceDetails(listOf(BASE_OFFENCE.code))
+      assertThat(res).isEqualTo(
+        listOf(
+          SdsOffenceDetails(
+            offenceCode = BASE_OFFENCE.code,
+            PcscMarkers(
+              inListA = false,
+              inListB = false,
+              inListC = false,
+              inListD = false,
+            ),
+            listOf(),
+          ),
+        ),
+      )
+    }
+
+    @Test
+    fun `Can fetch SDS markers for offence when SA2026 progression model exclusion schedule has not been published yet`() {
+      whenever(
+        scheduleRepository.findOneByActAndCode(
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.act,
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.code,
+        ),
+      ).thenReturn(
+        Schedule(
+          1000,
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.act,
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.code,
+          "/foo",
+          ScheduleStatus.DRAFT,
+        ),
+      )
+
+      whenever(
+        offenceScheduleMappingRepository.findBySchedulePartScheduleActAndSchedulePartScheduleCode(
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.act,
+          SENTENCING_ACT_2026_PROGRESSION_MODEL_EXCLUSION_SCHEDULE.code,
+        ),
+      ).thenReturn(listOf(OFFENCE_SCHEDULE_MAPPING_S13_P3))
+
+      val res = isOffenceInScheduleService.getSdsOffenceDetails(listOf(BASE_OFFENCE.code))
+      assertThat(res).isEqualTo(
+        listOf(
+          SdsOffenceDetails(
+            offenceCode = BASE_OFFENCE.code,
+            PcscMarkers(
+              inListA = false,
+              inListB = false,
+              inListC = false,
+              inListD = false,
+            ),
+            listOf(),
           ),
         ),
       )
@@ -314,12 +406,15 @@ class IsOffenceInScheduleServiceTest {
     private const val SCHEDULE_PART_ID_92 = 92L
     private const val SCHEDULE_PART_ID_93 = 93L
     private val SCHEDULE_15_ENTITY = Schedule(code = "15", id = 15, act = "Act", url = "url")
-    private val SCHEDULE_15_PART_1 = SchedulePart(id = SCHEDULE_PART_ID_92, partNumber = 1, schedule = SCHEDULE_15_ENTITY)
-    private val SCHEDULE_15_PART_2 = SchedulePart(id = SCHEDULE_PART_ID_93, partNumber = 2, schedule = SCHEDULE_15_ENTITY)
+    private val SCHEDULE_15_PART_1 =
+      SchedulePart(id = SCHEDULE_PART_ID_92, partNumber = 1, schedule = SCHEDULE_15_ENTITY)
+    private val SCHEDULE_15_PART_2 =
+      SchedulePart(id = SCHEDULE_PART_ID_93, partNumber = 2, schedule = SCHEDULE_15_ENTITY)
 
     private const val SCHEDULE_PART_ID_99 = 99L
     private val SCHEDULE_13_ENTITY = Schedule(code = "13", id = 13, act = "Act", url = "url")
-    private val SCHEDULE_13_PART_3 = SchedulePart(id = SCHEDULE_PART_ID_99, partNumber = 3, schedule = SCHEDULE_13_ENTITY)
+    private val SCHEDULE_13_PART_3 =
+      SchedulePart(id = SCHEDULE_PART_ID_99, partNumber = 3, schedule = SCHEDULE_13_ENTITY)
 
     private val BASE_OFFENCE = Offence(
       code = "AABB011",

--- a/src/test/resources/test_data/insert-progression-model-test-exclusions.sql
+++ b/src/test/resources/test_data/insert-progression-model-test-exclusions.sql
@@ -1,0 +1,13 @@
+INSERT INTO offence
+(code, description, revision_id, cjs_title, start_date, end_date, changed_date, created_date, last_updated_date)
+VALUES
+('PM01', 'Some exclusion', 570173, 'Some exclusion CJS', '2009-11-02', NULL, '2020-01-16 15:19:02.000', '2022-04-07 16:05:58.178', '2022-04-07 16:05:58.178'),
+('PM02', 'Another exclusion', 574415, 'Another exclusion CJS', '2015-03-13', NULL, '2020-06-17 15:31:26.000', '2022-04-07 16:05:58.178', '2022-04-07');
+
+-- actual schedule created in the UI. this is only for the tests
+INSERT INTO schedule (act, code, url, status)
+VALUES ('SA2026 Excluded Offences for Progression Model', 'SA2026 EOPM', '/test', 'LIVE');
+INSERT INTO schedule_part (schedule_id, part_number)
+VALUES ((SELECT id FROM schedule WHERE code = 'SA2026 EOPM'), 1);
+INSERT INTO offence_schedule_mapping (offence_id, schedule_part_id) values ((select id from offence o where o.code = 'PM01'), (select id from schedule_part where schedule_id = (select id from schedule where code = 'SA2026 EOPM' and part_number = 1)));
+INSERT INTO offence_schedule_mapping (offence_id, schedule_part_id) values ((select id from offence o where o.code = 'PM02'), (select id from schedule_part where schedule_id = (select id from schedule where code = 'SA2026 EOPM' and part_number = 1)));


### PR DESCRIPTION
Currently only contains the new Sentencing Act 2026 Exclusions from Progression Model schedule but may also contain the Schedule 13 Part 3 list as those are excluded from PM as well (if offence is before commencement).